### PR TITLE
Use WriteFile for config writes and fix mods queue creation

### DIFF
--- a/cfg/globalCfg.go
+++ b/cfg/globalCfg.go
@@ -35,14 +35,7 @@ func WriteGCfg() bool {
 		return false
 	}
 
-	_, err := os.Create(tempPath)
-
-	if err != nil {
-		cwlog.DoLogCW("WriteGCfg: os.Create failure")
-		return false
-	}
-
-	err = os.WriteFile(tempPath, outbuf.Bytes(), 0644)
+	err := os.WriteFile(tempPath, outbuf.Bytes(), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("WriteGCfg: WriteFile failure")
@@ -62,8 +55,7 @@ func setGlobalDefaults() {
 	/* Automatic global defaults */
 	if Global.Paths.DataFiles.DBFile == "" {
 		Global.Paths.DataFiles.DBFile = "playerdb.json"
-		_, err := os.Create(Global.Paths.DataFiles.DBFile)
-		if err != nil {
+		if err := os.WriteFile(Global.Paths.DataFiles.DBFile, []byte("{}"), 0644); err != nil {
 			cwlog.DoLogCW("setGlobalDefaults: Could not create " + Global.Paths.DataFiles.DBFile)
 		}
 	}

--- a/cfg/localCfg.go
+++ b/cfg/localCfg.go
@@ -41,14 +41,7 @@ func WriteLCfg() bool {
 		return false
 	}
 
-	_, err := os.Create(tempPath)
-
-	if err != nil {
-		cwlog.DoLogCW("WriteLCfg: os.Create failure")
-		return false
-	}
-
-	err = os.WriteFile(tempPath, outbuf.Bytes(), 0644)
+	err := os.WriteFile(tempPath, outbuf.Bytes(), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("WriteLCfg: WriteFile failure")

--- a/disc/roleList.go
+++ b/disc/roleList.go
@@ -34,14 +34,7 @@ func WriteRoleList() bool {
 		return false
 	}
 
-	_, err := os.Create(tempPath)
-
-	if err != nil {
-		cwlog.DoLogCW("Writecfg.RoleList: os.Create failure")
-		return false
-	}
-
-	err = os.WriteFile(tempPath, outbuf.Bytes(), 0644)
+	err := os.WriteFile(tempPath, outbuf.Bytes(), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("Writecfg.RoleList: WriteFile failure")
@@ -74,7 +67,7 @@ func ReadRoleList() bool {
 		newcfg := CreateRoleList()
 		RoleList = newcfg
 
-		_, err := os.Create(constants.RoleListFile)
+		err := os.WriteFile(constants.RoleListFile, []byte("{}"), 0644)
 		if err != nil {
 			cwlog.DoLogCW("Could not create RoleList.")
 			return false

--- a/fact/confGen.go
+++ b/fact/confGen.go
@@ -235,14 +235,7 @@ func GenerateFactorioConfig() bool {
 		return false
 	}
 
-	_, err := os.Create(tempPath)
-
-	if err != nil {
-		cwlog.DoLogCW("GenerateFactorioConfig: os.Create failure")
-		return false
-	}
-
-	err = os.WriteFile(tempPath, outbuf.Bytes(), 0644)
+	err := os.WriteFile(tempPath, outbuf.Bytes(), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("GenerateFactorioConfig: WriteFile failure")

--- a/fact/mapReset.go
+++ b/fact/mapReset.go
@@ -94,19 +94,20 @@ func Map_reset(doReport bool) {
 		cfg.Global.Paths.Folders.FactorioDir + "/" +
 		constants.ModsFolder + "/"
 
-	files, err := os.ReadDir(qPath)
+	_, err := os.Stat(qPath)
 	if err != nil {
-		cwlog.DoLogCW(err.Error())
-	}
-	_, err = os.Stat(qPath)
-	notfound := os.IsNotExist(err)
-
-	if notfound {
-		_, err = os.Create(qPath)
-		if err != nil {
+		if os.IsNotExist(err) {
+			if err := os.MkdirAll(qPath, os.ModePerm); err != nil {
+				cwlog.DoLogCW(err.Error())
+			}
+		} else {
 			cwlog.DoLogCW(err.Error())
 		}
 	} else {
+		files, err := os.ReadDir(qPath)
+		if err != nil {
+			cwlog.DoLogCW(err.Error())
+		}
 		for _, f := range files {
 			if strings.EqualFold(f.Name(), constants.ModSettingsName) {
 				err := os.Rename(qPath+f.Name(), modPath+f.Name())

--- a/fact/playerDB.go
+++ b/fact/playerDB.go
@@ -450,20 +450,8 @@ func WritePlayers() {
 	glob.PlayerListWriteLock.Lock()
 	defer glob.PlayerListWriteLock.Unlock()
 
-	dbPath := cfg.Global.Paths.Folders.ServersRoot + cfg.Global.Paths.DataFiles.DBFile
-	pdb, err := os.Create(dbPath)
-	if err != nil {
-		cwlog.DoLogCW("Couldn't write db file, path: %v", dbPath)
-		return
-	}
-	/*  close pdb on exit and check for its returned error */
-	defer func() {
-		if err := pdb.Close(); err != nil {
-			panic(err)
-		}
-	}()
-
 	glob.PlayerListLock.RLock()
+	defer glob.PlayerListLock.RUnlock()
 
 	outbuf := new(bytes.Buffer)
 	enc := json.NewEncoder(outbuf)
@@ -471,10 +459,9 @@ func WritePlayers() {
 		cwlog.DoLogCW("WritePlayers: enc.Encode failure")
 		return
 	}
-	glob.PlayerListLock.RUnlock()
 
 	nfilename := fmt.Sprintf("pdb-%s.tmp", cfg.Local.Callsign)
-	err = os.WriteFile(nfilename, outbuf.Bytes(), 0644)
+	err := os.WriteFile(nfilename, outbuf.Bytes(), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("Couldn't write db temp file.")

--- a/fact/util.go
+++ b/fact/util.go
@@ -276,14 +276,7 @@ func WriteAdminlist() int {
 	buf = buf + "\n]\n"
 	glob.PlayerListLock.RUnlock()
 
-	_, err := os.Create(wpath)
-
-	if err != nil {
-		cwlog.DoLogCW("WriteAdminlist: os.Create failure")
-		return -1
-	}
-
-	err = os.WriteFile(wpath, []byte(buf), 0644)
+	err := os.WriteFile(wpath, []byte(buf), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("WriteAdminlist: WriteFile failure")
@@ -362,14 +355,7 @@ func WriteWhitelist() int {
 		buf = buf + "\n]\n"
 		glob.PlayerListLock.RUnlock()
 
-		_, err := os.Create(wpath)
-
-		if err != nil {
-			cwlog.DoLogCW("WriteWhitelist: os.Create failure")
-			return -1
-		}
-
-		err = os.WriteFile(wpath, []byte(buf), 0644)
+		err := os.WriteFile(wpath, []byte(buf), 0644)
 
 		if err != nil {
 			cwlog.DoLogCW("WriteWhitelist: WriteFile failure")

--- a/fact/voteMap.go
+++ b/fact/voteMap.go
@@ -313,14 +313,7 @@ func WriteVotes() bool {
 		return false
 	}
 
-	_, err := os.Create(tempPath)
-
-	if err != nil {
-		cwlog.DoLogCW("WriteVotes: os.Create failure")
-		return false
-	}
-
-	err = os.WriteFile(tempPath, outbuf.Bytes(), 0644)
+	err := os.WriteFile(tempPath, outbuf.Bytes(), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("WriteVotes: WriteFile failure")

--- a/modupdate/util.go
+++ b/modupdate/util.go
@@ -50,14 +50,7 @@ func WriteModHistory() {
 		return
 	}
 
-	_, err := os.Create(tempPath)
-
-	if err != nil {
-		cwlog.DoLogCW("writeModHistory: os.Create failure")
-		return
-	}
-
-	err = os.WriteFile(tempPath, outbuf.Bytes(), 0644)
+	err := os.WriteFile(tempPath, outbuf.Bytes(), 0644)
 
 	if err != nil {
 		cwlog.DoLogCW("writeModHistory: WriteFile failure")
@@ -238,14 +231,7 @@ func WriteModsList(modList ModListData) bool {
 	}
 
 	os.Mkdir(util.GetModsFolder(), 0755)
-	_, err := os.Create(tempPath)
-
-	if err != nil {
-		cwlog.DoLogCW("writeModsList: os.Create failure")
-		return false
-	}
-
-	err = os.WriteFile(tempPath, outbuf.Bytes(), 0755)
+	err := os.WriteFile(tempPath, outbuf.Bytes(), 0755)
 
 	if err != nil {
 		cwlog.DoLogCW("writeModsList: WriteFile failure")


### PR DESCRIPTION
## Summary
- replace `os.Create`/write patterns with `os.WriteFile`
- fix mods queue initialization in `Map_reset`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684038e323d8832abfaa1dcb355002f3