### PR TITLE
Fix comment for soft mod detection

### DIFF
--- a/support/launcher.go
+++ b/support/launcher.go
@@ -407,7 +407,7 @@ func launchFactorio() {
 	/* Allow crash reports right away */
 	glob.LastCrashReport = time.Time{}
 
-	/* Clear this so we know if the the loaded map has our soft mod or not */
+	/* Clear this so we know if the loaded map has our soft mod or not */
 	glob.SoftModVersion = constants.Unknown
 	glob.OnlineCommand = constants.OnlineCommand
 	fact.OnlinePlayersLock.Lock()


### PR DESCRIPTION
## Summary
- correct the wording of the soft mod comment in `launcher.go`

## Testing
- `go vet ./...` *(fails: fact/playerDB.go:453:2: declared and not used: dbPath)*
- `go test ./...` *(fails to build)*

------
https://chatgpt.com/codex/tasks/task_e_6840519a6f2c832a8e4c98be5a55befa