### PR TITLE
Fix README typos in Discord permissions section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,4 +55,4 @@ Launch params:<br>
 
 ### Discord bot perms:
 The bot needs presence intent, server members intent, message content intent
-Perms: view channels, manage channels, Mange roles, send messages, emebed links, attach files, mention all roles, manage messages (delete message, if register code leaked), read message history, use application commands.
+Perms: view channels, manage channels, Manage roles, send messages, embed links, attach files, mention all roles, manage messages (delete message, if register code leaked), read message history, use application commands.


### PR DESCRIPTION
## Summary
- correct typos in `README.md` for required Discord permissions

## Testing
- `go test ./...` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_684051697a4c832a81da1ea17d391262