### PR TITLE
Fix lint warnings

### DIFF
--- a/banlist/banList.go
+++ b/banlist/banList.go
@@ -17,7 +17,9 @@ import (
 )
 
 var (
-	BanList     []banDataType
+	// BanList holds the current list of bans loaded from disk.
+	BanList []banDataType
+	// banListLock protects access to BanList.
 	banListLock sync.Mutex
 )
 
@@ -27,6 +29,8 @@ type banDataType struct {
 	Revoked  bool   `json:"-"`
 }
 
+// CheckBanList returns true if the provided username is currently banned.
+// A warning is optionally sent when doWarn is true.
 func CheckBanList(name string, doWarn bool) bool {
 	pname := strings.ToLower(name)
 	banListLock.Lock()
@@ -70,6 +74,7 @@ func CheckBanList(name string, doWarn bool) bool {
 	return false
 }
 
+// WatchBanFile monitors the ban file for changes and reloads it when modified.
 func WatchBanFile() {
 	for glob.ServerRunning {
 
@@ -102,6 +107,8 @@ func WatchBanFile() {
 	}
 }
 
+// ReadBanFile loads the ban file from disk. When firstboot is true the
+// notifications for changes are suppressed.
 func ReadBanFile(firstboot bool) {
 	banListLock.Lock()
 	defer banListLock.Unlock()

--- a/cfg/globalCfg.go
+++ b/cfg/globalCfg.go
@@ -13,10 +13,14 @@ import (
 )
 
 var (
-	Local  local
+	// Local holds local server configuration.
+	Local local
+	// Global holds global configuration shared across servers.
 	Global global
 )
 
+// WriteGCfg writes the global configuration to disk.
+// It returns true on success.
 func WriteGCfg() bool {
 	tempPath := constants.CWGlobalConfig + "." + Local.Callsign + ".tmp"
 	finalPath := constants.CWGlobalConfig
@@ -155,6 +159,8 @@ func setGlobalDefaults() {
 	}
 }
 
+// ReadGCfg loads the global configuration from disk.
+// It creates a default configuration when none exists.
 func ReadGCfg() bool {
 
 	_, err := os.Stat(constants.CWGlobalConfig)
@@ -162,37 +168,36 @@ func ReadGCfg() bool {
 
 	if notfound {
 		cwlog.DoLogCW("ReadGCfg: os.Stat failed, auto-defaults generated.")
-		newcfg := CreateGCfg()
+		newcfg := createGCfg()
 		Global = newcfg
 
 		setGlobalDefaults()
 		WriteGCfg()
 		return true
-	} else { /* Otherwise just read in the config */
-		file, err := os.ReadFile(constants.CWGlobalConfig)
+	}
 
-		if file != nil && err == nil {
-			newcfg := CreateGCfg()
-
-			err := json.Unmarshal([]byte(file), &newcfg)
-			if err != nil {
-				cwlog.DoLogCW("ReadGCfg: Unmarshal failure")
-				cwlog.DoLogCW(err.Error())
-				return false
-			}
-
-			Global = newcfg
-			setGlobalDefaults()
-
-			return true
-		} else {
-			cwlog.DoLogCW("ReadGCfg: ReadFile failure")
+	file, err := os.ReadFile(constants.CWGlobalConfig)
+	if file != nil && err == nil {
+		newcfg := createGCfg()
+		err := json.Unmarshal([]byte(file), &newcfg)
+		if err != nil {
+			cwlog.DoLogCW("ReadGCfg: Unmarshal failure")
+			cwlog.DoLogCW(err.Error())
 			return false
 		}
+
+		Global = newcfg
+		setGlobalDefaults()
+
+		return true
 	}
+
+	cwlog.DoLogCW("ReadGCfg: ReadFile failure")
+	return false
 }
 
-func CreateGCfg() global {
+// createGCfg returns a new empty global configuration structure.
+func createGCfg() global {
 	newcfg := global{}
 	return newcfg
 }

--- a/cfg/localCfg.go
+++ b/cfg/localCfg.go
@@ -14,6 +14,7 @@ import (
 	"github.com/martinhoefling/goxkcdpwgen/xkcdpwgen"
 )
 
+// GetGameLogURL builds the web URL to the current game log.
 func GetGameLogURL() string {
 	if Global.Paths.URLs.LogsPathWeb == "" {
 		return ""
@@ -26,6 +27,8 @@ func GetGameLogURL() string {
 		strings.TrimPrefix(glob.GameLogName, "log/"))
 }
 
+// WriteLCfg writes the local configuration to disk.
+// It returns true on success.
 func WriteLCfg() bool {
 	tempPath := constants.CWLocalConfig + "." + Local.Callsign + ".tmp"
 	finalPath := constants.CWLocalConfig
@@ -112,6 +115,7 @@ func setLocalDefaults() {
 	}
 }
 
+// ReadLCfg loads the local configuration from disk, creating defaults if needed.
 func ReadLCfg() bool {
 
 	_, err := os.Stat(constants.CWLocalConfig)
@@ -119,7 +123,7 @@ func ReadLCfg() bool {
 
 	if notfound {
 		cwlog.DoLogCW("ReadLCfg: os.Stat failed, auto-defaults generated.")
-		newcfg := CreateLCfg()
+		newcfg := createLCfg()
 		Local = newcfg
 		setLocalDefaults()
 		if !Local.Settings.AutoPause {
@@ -128,54 +132,52 @@ func ReadLCfg() bool {
 		Local.Settings.AdminOnlyPause = true
 		WriteLCfg() /* Write the defaults */
 		return true
-	} else { /* Just read the config */
+	}
 
-		file, err := os.ReadFile(constants.CWLocalConfig)
+	file, err := os.ReadFile(constants.CWLocalConfig)
+	if file != nil && err == nil {
+		newcfg := createLCfg()
 
-		if file != nil && err == nil {
-			newcfg := CreateLCfg()
-
-			err := json.Unmarshal([]byte(file), &newcfg)
-			if err != nil {
-				cwlog.DoLogCW("ReadLCfg: Unmarshal failure")
-				cwlog.DoLogCW(err.Error())
-				return false
-			}
-
-			Local = newcfg
-			setLocalDefaults()
-
-			/* Automatic local defaults */
-			found := false
-			for _, t := range constants.MapTypes {
-				if strings.EqualFold(Local.Settings.MapPreset, t) {
-					found = true
-				}
-			}
-			if !found {
-				Local.Settings.MapPreset = constants.MapTypes[1]
-				cwlog.DoLogCW("ReadLCfg: MapPreset not valid, setting to " + Local.Settings.MapPreset)
-			}
-
-			//Migrate old setting
-			if newcfg.Options.Whitelist {
-				newcfg.Options.MembersOnly = true
-				newcfg.Options.Whitelist = false
-			}
-			if newcfg.Options.RegularsOnly {
-				newcfg.Options.MembersOnly = false
-			}
-
-			return true
-		} else {
-			cwlog.DoLogCW("ReadLCfg: ReadFile failure")
+		err := json.Unmarshal([]byte(file), &newcfg)
+		if err != nil {
+			cwlog.DoLogCW("ReadLCfg: Unmarshal failure")
+			cwlog.DoLogCW(err.Error())
 			return false
 		}
 
+		Local = newcfg
+		setLocalDefaults()
+
+		/* Automatic local defaults */
+		found := false
+		for _, t := range constants.MapTypes {
+			if strings.EqualFold(Local.Settings.MapPreset, t) {
+				found = true
+			}
+		}
+		if !found {
+			Local.Settings.MapPreset = constants.MapTypes[1]
+			cwlog.DoLogCW("ReadLCfg: MapPreset not valid, setting to " + Local.Settings.MapPreset)
+		}
+
+		//Migrate old setting
+		if newcfg.Options.Whitelist {
+			newcfg.Options.MembersOnly = true
+			newcfg.Options.Whitelist = false
+		}
+		if newcfg.Options.RegularsOnly {
+			newcfg.Options.MembersOnly = false
+		}
+
+		return true
 	}
+
+	cwlog.DoLogCW("ReadLCfg: ReadFile failure")
+	return false
 }
 
-func CreateLCfg() local {
+// createLCfg returns a new empty local configuration structure.
+func createLCfg() local {
 	newcfg := local{}
 	return newcfg
 }

--- a/util/util.go
+++ b/util/util.go
@@ -10,6 +10,7 @@ import (
 	"ChatWire/disc"
 )
 
+// TrimPrefixIgnoreCase removes prefix from s in a case-insensitive manner.
 func TrimPrefixIgnoreCase(s, prefix string) string {
 	if strings.HasPrefix(strings.ToLower(s), strings.ToLower(prefix)) {
 		return s[len(prefix):]
@@ -17,12 +18,15 @@ func TrimPrefixIgnoreCase(s, prefix string) string {
 	return s
 }
 
+// ContainsIgnoreCase reports whether substr is within s ignoring case.
 func ContainsIgnoreCase(s, substr string) bool {
 	return strings.Contains(
 		strings.ToLower(s), strings.ToLower(substr),
 	)
 }
 
+// GetFactorioFolder returns the path to the Factorio installation for the
+// current server.
 func GetFactorioFolder() string {
 	return cfg.Global.Paths.Folders.ServersRoot +
 		cfg.Global.Paths.ChatWirePrefix +
@@ -30,8 +34,8 @@ func GetFactorioFolder() string {
 		cfg.Global.Paths.Folders.FactorioDir + "/"
 }
 
+// GetModsFolder returns the path to the mod directory.
 func GetModsFolder() string {
-	//Mod folder path
 	return cfg.Global.Paths.Folders.ServersRoot +
 		cfg.Global.Paths.ChatWirePrefix +
 		cfg.Local.Callsign + "/" +
@@ -39,6 +43,7 @@ func GetModsFolder() string {
 		constants.ModsFolder + "/"
 }
 
+// GetSavesFolder returns the path to the saves directory.
 func GetSavesFolder() string {
 	return cfg.Global.Paths.Folders.ServersRoot +
 		cfg.Global.Paths.ChatWirePrefix +
@@ -47,7 +52,7 @@ func GetSavesFolder() string {
 		cfg.Global.Paths.Folders.Saves
 }
 
-/*  IsPatreon checks if player has patreon role */
+// IsPatreon checks if player has the Patreon role.
 func IsPatreon(id string) bool {
 	if id == "" || disc.DS == nil {
 		return false
@@ -70,7 +75,7 @@ func IsPatreon(id string) bool {
 	return false
 }
 
-/*  IsNitro checks if player has nitro role */
+// IsNitro checks if player has the Nitro role.
 func IsNitro(id string) bool {
 	if id == "" || disc.DS == nil {
 		return false
@@ -91,8 +96,8 @@ func IsNitro(id string) bool {
 	return false
 }
 
-/* Convert string to bool
- * True, error */
+// StringToBool converts a string to a boolean. The second return value
+// indicates whether the conversion failed.
 func StringToBool(txt string) (bool, bool) {
 	if strings.ToLower(txt) == "true" ||
 		strings.ToLower(txt) == "t" ||
@@ -117,16 +122,15 @@ func StringToBool(txt string) (bool, bool) {
 	return false, true
 }
 
-/* Bool to string */
+// BoolToOnOff converts a boolean to the strings "on" or "off".
 func BoolToOnOff(b bool) string {
 	if b {
 		return "on"
-	} else {
-		return "off"
 	}
+	return "off"
 }
 
-/* Delete old signal files */
+// ClearOldSignals removes leftover signal files from previous runs.
 func ClearOldSignals() {
 	if err := os.Remove(".qrestart"); err == nil {
 		cwlog.DoLogCW("old .qrestart removed.")


### PR DESCRIPTION
## Summary
- clean up comments and exported names flagged by golint
- drop redundant `else` branches in config loaders

## Testing
- `go vet ./...`
- `go test ./...`
- `golint ./... | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68406a1dba54832ab8565ea10eba52a8