### PR TITLE
Fix mod update duplicate handling

### DIFF
--- a/modupdate/fileutil.go
+++ b/modupdate/fileutil.go
@@ -1,0 +1,24 @@
+package modupdate
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+)
+
+// writeJSONAtomic writes data to path as JSON using a temporary file.
+func writeJSONAtomic(path string, data interface{}, perm os.FileMode) error {
+	tempPath := path + ".tmp"
+
+	outbuf := new(bytes.Buffer)
+	enc := json.NewEncoder(outbuf)
+	enc.SetIndent("", "\t")
+	if err := enc.Encode(data); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(tempPath, outbuf.Bytes(), perm); err != nil {
+		return err
+	}
+	return os.Rename(tempPath, path)
+}

--- a/modupdate/newUpdate.go
+++ b/modupdate/newUpdate.go
@@ -356,3 +356,29 @@ func parseDep(input string) depRequires {
 
 	return depRequires{name: name, equality: parseOperator(equality), version: version, optional: optional, incompatible: incompatible}
 }
+
+// addDownload checks for duplicate downloads and replaces older entries.
+func addDownload(input downloadData, list []downloadData) []downloadData {
+	for i, item := range list {
+		if item.Name == input.Name {
+			newer, err := checkVersion(EO_GREATER, item.Data.Version, input.Data.Version)
+			if err != nil {
+				cwlog.DoLogCW("addDownload: Unable to parse version")
+				return list
+			}
+			if newer {
+				list[i] = input
+				if resolveDepsDebug {
+					cwlog.DoLogCW("Added newer download: %v-%v", input.Name, input.Version)
+				}
+			} else if resolveDepsDebug {
+				cwlog.DoLogCW("DID NOT ADD download: %v-%v", input.Name, input.Version)
+			}
+			return list
+		}
+	}
+	if resolveDepsDebug {
+		cwlog.DoLogCW("Added download: %v-%v", input.Name, input.Version)
+	}
+	return append(list, input)
+}


### PR DESCRIPTION
## Summary
- refactor modupdate package
- move history helpers to `modHistory.go`
- deduplicate JSON writes via `writeJSONAtomic`
- keep duplicate download check in `newUpdate.go`

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840707d651c832a8cebb9401df14392