### PR TITLE
Add banish ping role

### DIFF
--- a/cfg/globalCfg.go
+++ b/cfg/globalCfg.go
@@ -24,7 +24,7 @@ var (
 func WriteGCfg() bool {
 	finalPath := constants.CWGlobalConfig
 
-	Global.Discord.Comment = "RoleID to ping for suspicious activity, if any."
+	Global.Discord.Comment = "RoleIDs to ping for suspicious or banishment events, if any."
 	Global.Discord.Roles.Comment = "These are role names, ChatWire will auto-resolve the IDs and cache them."
 	Global.Discord.Roles.RoleCache.Comment = "Cached Role IDs, in case lookup is slow or fails."
 	Global.Options.Comment = "RoleID to ping on map resets, if any."

--- a/cfg/struct.go
+++ b/cfg/struct.go
@@ -23,6 +23,7 @@ type discord struct {
 	Roles           roles
 	Comment         string `form:"-"`
 	SusPingRole     string `web:"Suspicious Ping RoleID"`
+	BanishPingRole  string `web:"Banish Ping RoleID"`
 }
 
 type roles struct {

--- a/support/launcher.go
+++ b/support/launcher.go
@@ -43,7 +43,7 @@ func SyncMods(i *discordgo.InteractionCreate, optionalFileName string) bool {
 
 	fileName := ""
 	if optionalFileName == "" {
-		_, fileName, _ = getSaveGame(true)
+		_, fileName, _ = GetSaveGame(true)
 	} else {
 		fileName = optionalFileName
 	}
@@ -427,7 +427,7 @@ func launchFactorio() {
 	}
 
 	/* Find, test and load newest save game available */
-	found, fileName, folderName := getSaveGame(true)
+	found, fileName, folderName := GetSaveGame(true)
 	if !found {
 		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "ERROR", "Unable to access save-games.", glob.COLOR_RED)
 		fact.SetAutolaunch(false, true)
@@ -503,7 +503,7 @@ func launchFactorio() {
 		tempargs = append(tempargs, "true")
 	}
 
-	modFiles := getModFiles()
+	modFiles := GetModFiles()
 	if len(modFiles) > 0 {
 		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Status", "Loading mods...", glob.COLOR_GREEN)
 	}

--- a/support/pipeHandle.go
+++ b/support/pipeHandle.go
@@ -124,19 +124,34 @@ func handlePlayerReport(input *handleData) bool {
 	if strings.HasPrefix(input.line, "[REPORT]") {
 		cwlog.DoLogGame(input.line)
 		if input.wordListLen >= 3 {
-			pingStr := ""
-			if cfg.Global.Discord.SusPingRole != "" {
-				pingStr = fmt.Sprintf("<@&%v>", cfg.Global.Discord.SusPingRole)
-			}
-			buf := ""
-			if cfg.GetGameLogURL() == "" {
-				buf = fmt.Sprintf("Server: %v, Reporter: %v: Report:\n %v\n%v",
-					cfg.Local.Callsign+"-"+cfg.Local.Name, input.wordList[1], strings.Join(input.wordList[2:], " "), pingStr)
+			msg := strings.Join(input.wordList[1:], " ")
+			lmsg := strings.ToLower(msg)
+			if strings.HasSuffix(lmsg, "has been banished.") {
+				pingStr := ""
+				if cfg.Global.Discord.BanishPingRole != "" {
+					pingStr = fmt.Sprintf("<@&%v>", cfg.Global.Discord.BanishPingRole)
+				}
+				sbuf := cfg.Global.GroupName + "-" + cfg.Local.Callsign + ": " + cfg.Local.Name + ": " + msg
+				if pingStr != "" {
+					fact.CMS(cfg.Global.Discord.ReportChannel, fmt.Sprintf("%v\n%v", sbuf, pingStr))
+				} else {
+					fact.CMS(cfg.Global.Discord.ReportChannel, sbuf)
+				}
 			} else {
-				buf = fmt.Sprintf("Server: %v, Reporter: %v: Report:\n %v\nLog: %v\n%v",
-					cfg.Local.Callsign+"-"+cfg.Local.Name, input.wordList[1], strings.Join(input.wordList[2:], " "), cfg.GetGameLogURL(), pingStr)
+				pingStr := ""
+				if cfg.Global.Discord.SusPingRole != "" {
+					pingStr = fmt.Sprintf("<@&%v>", cfg.Global.Discord.SusPingRole)
+				}
+				buf := ""
+				if cfg.GetGameLogURL() == "" {
+					buf = fmt.Sprintf("Server: %v, Reporter: %v: Report:\n %v\n%v",
+						cfg.Local.Callsign+"-"+cfg.Local.Name, input.wordList[1], strings.Join(input.wordList[2:], " "), pingStr)
+				} else {
+					buf = fmt.Sprintf("Server: %v, Reporter: %v: Report:\n %v\nLog: %v\n%v",
+						cfg.Local.Callsign+"-"+cfg.Local.Name, input.wordList[1], strings.Join(input.wordList[2:], " "), cfg.GetGameLogURL(), pingStr)
+				}
+				fact.LogGameCMS(true, cfg.Global.Discord.ReportChannel, buf)
 			}
-			fact.LogGameCMS(true, cfg.Global.Discord.ReportChannel, buf)
 		}
 		return true
 	}


### PR DESCRIPTION
## Summary
- add `BanishPingRole` field in Discord config struct
- ping banish role when bans occur
- only trigger on report lines ending with "has been banished."
- re-export GetSaveGame and GetModFiles helpers

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840af8fa2d8832a9229690340644068