### PR TITLE
Add constant for RCON port offset

### DIFF
--- a/cfg/globalCfg.go
+++ b/cfg/globalCfg.go
@@ -57,7 +57,8 @@ func setGlobalDefaults() {
 		Global.Paths.URLs.Domain = "localhost"
 	}
 	if Global.Options.RconOffset == 0 {
-		Global.Options.RconOffset = 10000
+		// Apply default RCON port offset
+		Global.Options.RconOffset = constants.RconPortOffset
 	}
 	if Global.GroupName == "" {
 		Global.GroupName = glob.RandomBase64String(3)

--- a/constants/consts.go
+++ b/constants/consts.go
@@ -37,6 +37,8 @@ const (
 	ModPackCooldownMin  = 5
 	MaxModPacks         = 4
 	ErrMsgDelay         = time.Second * 3
+	// Default offset added to Factorio server port for RCON
+	RconPortOffset = 10000
 
 	/* Spam auto-ban settings */
 	SpamScoreLimit   = 30

--- a/main.go
+++ b/main.go
@@ -274,8 +274,8 @@ func initMaps() {
 	glob.PlayerList = make(map[string]*glob.PlayerData)
 	glob.PassList = make(map[string]*glob.PassData)
 
-	/* Generate number to alpha map, used for auto port assignment */
-	pos := 10000
+	/* Generate number to alpha map, used for auto port assignment starting at constants.RconPortOffset */
+	pos := constants.RconPortOffset
 	for i := 'a'; i <= 'z'; i++ {
 		glob.AlphaValue[string(i)] = pos
 		pos++


### PR DESCRIPTION
## Summary
- introduce `constants.RconPortOffset`
- use this value when setting `Global.Options.RconOffset`
- reference the constant when seeding `glob.AlphaValue`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840bb40b24c832a8453723048d2fc77