### PR TITLE
Add constants for message limits and mod history

### DIFF
--- a/commands/moderator/uploadData.go
+++ b/commands/moderator/uploadData.go
@@ -90,7 +90,7 @@ func handleDataFile(attachmentUrl, typeName string) []byte {
 		return nil
 	}
 	if name == typeName {
-		if len(data) > MaxModSettingsSize {
+               if len(data) > constants.MaxModSettingsSize {
 			glob.UpdateMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.UpdateMessage, "Status",
 				"**The "+typeName+" is too large, skipping... **", glob.COLOR_RED)
 			return nil

--- a/commands/moderator/uploadUtil.go
+++ b/commands/moderator/uploadUtil.go
@@ -1,14 +1,12 @@
 package moderator
 
 import (
-	"ChatWire/fact"
-	"sync"
+       "ChatWire/fact"
+       "sync"
 )
 
 const (
-	saveGameName       = "save-game"
-	MaxModSettingsSize = 1024 * 1024 //1MB
-	MaxModListSize     = 1024 * 1024 //1MB
+       saveGameName = "save-game"
 )
 
 var (

--- a/constants/consts.go
+++ b/constants/consts.go
@@ -84,8 +84,24 @@ const (
 	/* Throttle Discord chat */
 	CMSRate            = 500 * time.Millisecond  //Time we spend waiting for buffer to fill up once active
 	CMSRestTime        = 3500 * time.Millisecond //Time to sleep after sending a message
-	CMSPollRate        = 100 * time.Millisecond  //Time between polls
-	MaxDiscordAttempts = 90
+        CMSPollRate        = 100 * time.Millisecond  //Time between polls
+        MaxDiscordAttempts = 90
+
+	/* Discord limits */
+	MaxDiscordMsgLen = 2000
+	
+	/* Auto port assignment */
+	AlphaStartValue = 10000
+	
+	/* Mod history settings */
+	ModHistoryKeyStart = 10000
+	ModHistoryMaxKey   = 99999
+	MaxModHistory      = 250
+	ModHistoryPageSize = 25
+	
+	/* Moderator uploads */
+	MaxModSettingsSize = 1024 * 1024 //1MB
+	MaxModListSize     = 1024 * 1024 //1MB
 )
 
 /* Factorio map preset names */

--- a/fact/util.go
+++ b/fact/util.go
@@ -26,8 +26,7 @@ import (
 )
 
 const (
-	MaxZipSize       = 1024 * 1024 * 1024 //1gb
-	maxDiscordMsgLen = 2000
+       MaxZipSize = 1024 * 1024 * 1024 //1gb
 )
 
 var (
@@ -432,7 +431,7 @@ func WriteFact(format string, args ...interface{}) {
 
 		plen := len(buf)
 
-		if plen > 2000 {
+               if plen > constants.MaxDiscordMsgLen {
 			cwlog.DoLogCW("Message to Factorio, too long... Not sending.")
 			return
 		} else if plen <= 1 {
@@ -1265,7 +1264,7 @@ func GetUpdateCachePath() string {
 /* Write a Discord message to the buffer */
 func CMS(channel string, text string) {
 
-	text = sclean.TruncateStringEllipsis(text, maxDiscordMsgLen)
+       text = sclean.TruncateStringEllipsis(text, constants.MaxDiscordMsgLen)
 	/* Split at newlines, so we can batch neatly */
 	lines := strings.Split(text, "\n")
 

--- a/main.go
+++ b/main.go
@@ -275,7 +275,7 @@ func initMaps() {
 	glob.PassList = make(map[string]*glob.PassData)
 
 	/* Generate number to alpha map, used for auto port assignment */
-	pos := 10000
+pos := constants.AlphaStartValue
 	for i := 'a'; i <= 'z'; i++ {
 		glob.AlphaValue[string(i)] = pos
 		pos++

--- a/modupdate/modHistory.go
+++ b/modupdate/modHistory.go
@@ -1,34 +1,28 @@
 package modupdate
 
 import (
-	"ChatWire/cfg"
-	"ChatWire/cwlog"
-	"ChatWire/util"
-	"encoding/json"
-	"fmt"
-	"math/rand/v2"
-	"os"
-	"strconv"
-	"strings"
+       "ChatWire/cfg"
+       "ChatWire/constants"
+       "ChatWire/cwlog"
+       "ChatWire/util"
+       "encoding/json"
+       "fmt"
+       "math/rand/v2"
+       "os"
+       "strconv"
+       "strings"
 )
 
 var (
-	rollbackList []ModHistoryItem
-	rollbackKey  int
-)
-
-const (
-	keyStart      = 10000
-	maxKey        = 99999
-	maxModHistory = 250
-	maxItemsPage  = 25
+       rollbackList []ModHistoryItem
+       rollbackKey  int
 )
 
 func ListHistory() string {
 	buf := ""
 
-	for i, item := range ModHistory.History {
-		if i > maxItemsPage {
+       for i, item := range ModHistory.History {
+               if i > constants.ModHistoryPageSize {
 			buf = buf + "\n...\n"
 			break
 		}
@@ -73,8 +67,8 @@ func ModUpdateRollback(value uint64) string {
 	 * Apply changes and disable mod update automatically and NOTE UPDATES ARE DISABLED
 	 */
 
-	buf := ""
-	if value >= 10000 {
+       buf := ""
+       if value >= constants.ModHistoryKeyStart {
 		if int(value) == rollbackKey {
 			rollbackKey = 0
 
@@ -89,8 +83,8 @@ func ModUpdateRollback(value uint64) string {
 	numHist := uint64(len(ModHistory.History))
 
 	//Unlikely but better to be safe
-	if numHist > maxModHistory {
-		numHist = maxModHistory
+       if numHist > constants.MaxModHistory {
+               numHist = constants.MaxModHistory
 	}
 
 	if value < 1 || value > numHist {
@@ -114,8 +108,8 @@ func ModUpdateRollback(value uint64) string {
 			buf = buf + "Remove " + item.Name + "-" + item.Version + "\n"
 		}
 	}
-	if rollbackList != nil {
-		rollbackKey = keyStart + rand.IntN(maxKey-keyStart)
+       if rollbackList != nil {
+               rollbackKey = constants.ModHistoryKeyStart + rand.IntN(constants.ModHistoryMaxKey-constants.ModHistoryKeyStart)
 		buf = "**Roll-back to #" + strconv.FormatUint(value, 10) + ": ACTION LIST:**\n\n" + buf
 		buf = buf + "\n**To perform the roll-back type: `/editmods mod-update-rollback:" + strconv.FormatUint(uint64(rollbackKey), 10) + "`**\n"
 	}

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -139,7 +139,7 @@ func MainLoops() {
 						for _, line := range factmsg {
 							oldlen := len(buf) + 1
 							addlen := len(line)
-							if oldlen+addlen >= 2000 {
+                                                       if oldlen+addlen >= constants.MaxDiscordMsgLen {
 								disc.SmartWriteDiscord(cfg.Local.Channel.ChatChannel, buf)
 								glob.BootMessage = nil
 								glob.UpdateMessage = nil
@@ -159,7 +159,7 @@ func MainLoops() {
 						for _, line := range moder {
 							oldlen := len(buf) + 1
 							addlen := len(line)
-							if oldlen+addlen >= 2000 {
+                                                       if oldlen+addlen >= constants.MaxDiscordMsgLen {
 								disc.SmartWriteDiscord(cfg.Global.Discord.ReportChannel, buf)
 								buf = line
 							} else {


### PR DESCRIPTION
## Summary
- centralize various numeric limits in `constants/consts.go`
- use new constants across the codebase

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840bb3cf5ac832a9c752b530a994414