### PR TITLE
Add global config file watcher

### DIFF
--- a/cfg/globalCfg.go
+++ b/cfg/globalCfg.go
@@ -5,11 +5,13 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"time"
 
 	"ChatWire/constants"
 	"ChatWire/cwlog"
 	"ChatWire/glob"
 	"ChatWire/util"
+	"ChatWire/watcher"
 )
 
 var (
@@ -183,4 +185,13 @@ func ReadGCfg() bool {
 func createGCfg() global {
 	newcfg := global{}
 	return newcfg
+}
+
+// WatchGCfg monitors the global configuration file for changes.
+func WatchGCfg() {
+	watcher.Watch(constants.CWGlobalConfig, 5*time.Second, &glob.ServerRunning, func() {
+		glob.GlobalCfgUpdatedLock.Lock()
+		glob.GlobalCfgUpdated = true
+		glob.GlobalCfgUpdatedLock.Unlock()
+	})
 }

--- a/glob/var.go
+++ b/glob/var.go
@@ -73,6 +73,10 @@ var (
 	PlayerListSeenDirty     = false
 	PlayerListSeenDirtyLock sync.Mutex
 
+	/* Global config status */
+	GlobalCfgUpdated     = false
+	GlobalCfgUpdatedLock sync.Mutex
+
 	/* Factorio server watchdog */
 	NoResponseCount = 0
 

--- a/watcher/watch.go
+++ b/watcher/watch.go
@@ -1,0 +1,32 @@
+package watcher
+
+import (
+	"os"
+	"time"
+)
+
+// Watch monitors a file and invokes cb whenever the file is modified.
+// The loop stops when running is nil or *running becomes false.
+func Watch(path string, interval time.Duration, running *bool, cb func()) {
+	for running == nil || *running {
+		initial, err := os.Stat(path)
+		if err != nil {
+			time.Sleep(time.Minute)
+			continue
+		}
+
+		time.Sleep(interval)
+		for running == nil || *running {
+			time.Sleep(interval)
+
+			stat, err := os.Stat(path)
+			if err != nil {
+				break
+			}
+			if stat.Size() != initial.Size() || stat.ModTime() != initial.ModTime() {
+				cb()
+				break
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a generic file watcher package
- use it for player database watching
- monitor global config file for changes
- reload and apply updates when config changes

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68424c036cac832a8c75fccb92662f7b