### PR TITLE
Improve mod-history options

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -225,8 +225,8 @@ var cmds = []glob.CommandData{
 				Type:        discordgo.ApplicationCommandOptionBoolean,
 			},
 			{
-				Name:        "list-mods",
-				Description: "List all installed mods",
+				Name:        "show-mods",
+				Description: "List installed mods",
 				Type:        discordgo.ApplicationCommandOptionBoolean,
 			},
 			{
@@ -245,13 +245,13 @@ var cmds = []glob.CommandData{
 				Type:        discordgo.ApplicationCommandOptionString,
 			},
 			{
-				Name:        "list-versions",
-				Description: "Show mod version preferences",
+				Name:        "list-version-prefs",
+				Description: "Show version preferences for mods",
 				Type:        discordgo.ApplicationCommandOptionBoolean,
 			},
 			{
-				Name:        "set-version",
-				Description: "Set mod version prefs: name=ver,mod=auto",
+				Name:        "set-version-pref",
+				Description: "Set version preference: mod=ver or mod=auto",
 				Type:        discordgo.ApplicationCommandOptionString,
 			},
 			{

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -226,7 +226,7 @@ var cmds = []glob.CommandData{
 			},
 			{
 				Name:        "show-mods",
-				Description: "List installed mods",
+				Description: "List installed mods and version preferences",
 				Type:        discordgo.ApplicationCommandOptionBoolean,
 			},
 			{
@@ -243,11 +243,6 @@ var cmds = []glob.CommandData{
 				Name:        "add-mod",
 				Description: "Add mods by name or URL. mod1, mod2URL",
 				Type:        discordgo.ApplicationCommandOptionString,
-			},
-			{
-				Name:        "list-version-prefs",
-				Description: "Show version preferences for mods",
-				Type:        discordgo.ApplicationCommandOptionBoolean,
 			},
 			{
 				Name:        "set-version-pref",

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -211,7 +211,12 @@ var cmds = []glob.CommandData{
 		Options: []glob.OptionData{
 			{
 				Name:        "mod-history",
-				Description: "Input: Page Number. See mod history and blacklist",
+				Description: "Show recent mod history",
+				Type:        discordgo.ApplicationCommandOptionBoolean,
+			},
+			{
+				Name:        "full-history",
+				Description: "Show extended mod history (large)",
 				Type:        discordgo.ApplicationCommandOptionBoolean,
 			},
 			{

--- a/commands/moderator/editMods.go
+++ b/commands/moderator/editMods.go
@@ -33,7 +33,9 @@ func EditMods(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 
 		switch oName {
 		case "mod-history":
-			tmsg = tmsg + modupdate.ListHistory()
+			tmsg = tmsg + modupdate.ListHistory(false)
+		case "full-history":
+			tmsg = tmsg + modupdate.ListHistory(true)
 		case "clear-history":
 			tmsg = tmsg + modupdate.ClearHistory()
 		case "list-mods":
@@ -63,7 +65,12 @@ func EditMods(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 	if tmsg == "" {
 		tmsg = "Unknown error"
 	}
-	disc.InteractionEphemeralResponseColor(i, "Edit-Mods", tmsg, glob.COLOR_CYAN)
+
+	if len(tmsg) > constants.MaxDiscordMsgLen {
+		disc.InteractionEphemeralFileResponse(i, "Edit-Mods", "See attached history.", "mod-history.txt", []byte(tmsg))
+	} else {
+		disc.InteractionEphemeralResponseColor(i, "Edit-Mods", tmsg, glob.COLOR_CYAN)
+	}
 }
 
 func clearAllMods() string {

--- a/commands/moderator/editMods.go
+++ b/commands/moderator/editMods.go
@@ -38,7 +38,7 @@ func EditMods(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 			tmsg = tmsg + modupdate.ListHistory(true)
 		case "clear-history":
 			tmsg = tmsg + modupdate.ClearHistory()
-		case "list-mods":
+		case "show-mods":
 			tmsg = tmsg + listMods()
 		case "enable-mod":
 			msg = toggleMod(i, option.StringValue(), true)
@@ -48,9 +48,9 @@ func EditMods(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 			tmsg = tmsg + msg + "\n"
 		case "add-mod":
 			tmsg = tmsg + addMod(i, option.StringValue())
-		case "list-versions":
+		case "list-version-prefs":
 			tmsg = tmsg + listVersions()
-		case "set-version":
+		case "set-version-pref":
 			tmsg = tmsg + setVersion(i, option.StringValue())
 		case "clear-all-mods":
 			msg = clearAllMods()

--- a/commands/moderator/editMods.go
+++ b/commands/moderator/editMods.go
@@ -39,7 +39,7 @@ func EditMods(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 		case "clear-history":
 			tmsg = tmsg + modupdate.ClearHistory()
 		case "show-mods":
-			tmsg = tmsg + listMods()
+			tmsg = tmsg + showMods()
 		case "enable-mod":
 			msg = toggleMod(i, option.StringValue(), true)
 			tmsg = tmsg + msg + "\n"
@@ -48,8 +48,6 @@ func EditMods(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 			tmsg = tmsg + msg + "\n"
 		case "add-mod":
 			tmsg = tmsg + addMod(i, option.StringValue())
-		case "list-version-prefs":
-			tmsg = tmsg + listVersions()
 		case "set-version-pref":
 			tmsg = tmsg + setVersion(i, option.StringValue())
 		case "clear-all-mods":
@@ -171,7 +169,7 @@ func parseModName(input string) (string, bool) {
 	}
 }
 
-func listMods() string {
+func showMods() string {
 	modFiles, err := modupdate.GetModFiles()
 	if err != nil {
 		return "Unable to read mod files."
@@ -179,44 +177,54 @@ func listMods() string {
 	modList, _ := modupdate.GetModList()
 	mergedMods := modupdate.MergeModLists(modFiles, modList)
 
+	prefs := modedit.ReadPrefs()
+	prefMap := map[string]string{}
+	for _, p := range prefs.Mods {
+		prefMap[strings.ToLower(p.Name)] = p.Version
+	}
+
 	ebuf := ""
 	for _, item := range mergedMods {
-		if item.Name == "base" {
-			continue
-		}
-		if !item.Enabled {
+		if item.Name == "base" || !item.Enabled {
 			continue
 		}
 		if ebuf != "" {
-			ebuf = ebuf + "\n"
+			ebuf += "\n"
 		}
+		line := ""
 		if modupdate.IsBaseMod(item.Name) {
-			ebuf = ebuf + item.Name + " (base mod)"
+			line = item.Name + " (base mod)"
 		} else if item.Version != "" {
-			ebuf = ebuf + item.Name + "-" + item.Version
+			line = item.Name + "-" + item.Version
 		} else {
-			ebuf = ebuf + item.Name
+			line = item.Name
 		}
+		if v, ok := prefMap[strings.ToLower(item.Name)]; ok && v != "" {
+			line += " (force " + v + ")"
+		}
+		ebuf += line
 	}
 
 	dbuf := ""
 	for _, item := range mergedMods {
-		if item.Name == "base" {
-			continue
-		}
-		if item.Enabled {
+		if item.Name == "base" || item.Enabled {
 			continue
 		}
 		if dbuf != "" {
-			dbuf = dbuf + "\n"
+			dbuf += "\n"
 		}
+		line := ""
 		if modupdate.IsBaseMod(item.Name) {
-			dbuf = dbuf + item.Name + " (base mod)"
+			line = item.Name + " (base mod)"
 		} else if item.Version != constants.Unknown {
-			dbuf = dbuf + item.Name + " (" + item.Version + ")"
+			line = item.Name + " (" + item.Version + ")"
 		} else {
-			dbuf = dbuf + item.Name
+			line = item.Name
 		}
+		if v, ok := prefMap[strings.ToLower(item.Name)]; ok && v != "" {
+			line += " (force " + v + ")"
+		}
+		dbuf += line
 	}
 
 	if ebuf == "" {
@@ -313,31 +321,6 @@ func enableStr(b bool, pastTense bool) string {
 			return "disable"
 		}
 	}
-}
-
-func listVersions() string {
-	prefs := modedit.ReadPrefs()
-	if len(prefs.Mods) == 0 {
-		return "No version preferences set."
-	}
-	mods, _ := modupdate.GetModFiles()
-	inst := map[string]string{}
-	for _, m := range mods {
-		inst[strings.ToLower(m.Name)] = m.Version
-	}
-	buf := ""
-	for _, v := range prefs.Mods {
-		if buf != "" {
-			buf += "\n"
-		}
-		iv := inst[strings.ToLower(v.Name)]
-		if iv != "" {
-			buf += v.Name + " -> " + v.Version + " (installed: " + iv + ")"
-		} else {
-			buf += v.Name + " -> " + v.Version
-		}
-	}
-	return buf
 }
 
 func setVersion(i *discordgo.InteractionCreate, input string) string {

--- a/modupdate/modHistory.go
+++ b/modupdate/modHistory.go
@@ -10,34 +10,41 @@ import (
 	"strings"
 )
 
-func ListHistory() string {
-	buf := ""
+func ListHistory(full bool) string {
+	if len(ModHistory.History) == 0 {
+		return "**Mod History:**\n\nMod history is empty."
+	}
 
-	for i, item := range ModHistory.History {
-		if i > constants.ModHistoryPageSize {
+	buf := ""
+	count := 0
+
+	for i := len(ModHistory.History) - 1; i >= 0; i-- {
+		item := ModHistory.History[i]
+
+		if !full && count >= constants.ModHistoryPageSize {
 			buf = buf + "\n...\n"
 			break
 		}
 
+		entry := ""
 		if item.Name == BootName {
-			buf = buf + item.Name + "\n"
+			entry = entry + item.Name + "\n"
 		} else {
-			buf = buf + fmt.Sprintf("**%4v: %v**\n",
-				i+1, item.Name)
+			entry = entry + fmt.Sprintf("**%4v: %v**\n", i+1, item.Name)
 		}
 		if item.Notes != "" {
-			buf = buf + item.Notes + "\n"
+			entry = entry + item.Notes + "\n"
 		}
 		if item.Version != "" {
 			if item.OldVersion != "0.0.0" {
-				buf = buf + item.OldVersion + " -> "
+				entry = entry + item.OldVersion + " -> "
 			}
-			buf = buf + item.Version + "\n"
+			entry = entry + item.Version + "\n"
 		}
-		buf = buf + item.Date.UTC().Format("01-02-2006 15:04:05") + " UTC\n\n"
-	}
-	if buf == "" {
-		buf = "Mod history is empty."
+		entry = entry + item.Date.UTC().Format("01-02-2006 15:04:05") + " UTC\n\n"
+
+		buf = buf + entry
+		count++
 	}
 
 	return "**Mod History:**\n\n" + buf


### PR DESCRIPTION
## Summary
- add ephemeral file response helper
- truncate mod-history output only if too long, send as attachment
- simplify ListHistory with no message length cap

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843920e8f88832a91eae8ae1b37b656