### PR TITLE
Add HTTPS status panel

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -498,6 +498,12 @@ var cmds = []glob.CommandData{
 		Type:        discordgo.ChatApplicationCommand,
 	},
 		Function: user.Scoreboard, PrimaryOnly: true},
+	{AppCmd: glob.AppCmdData{
+		Name:        "web-panel",
+		Description: "Get a temporary control panel link",
+		Type:        discordgo.ChatApplicationCommand,
+	},
+		Function: moderator.WebPanelLink, ModeratorOnly: true},
 	/* PLAYER COMMANDS -------------------- */
 	{AppCmd: glob.AppCmdData{
 		Name:        "list-mods",

--- a/commands/moderator/panel.go
+++ b/commands/moderator/panel.go
@@ -1,0 +1,25 @@
+package moderator
+
+import (
+	"fmt"
+
+	"github.com/bwmarrin/discordgo"
+
+	"ChatWire/cfg"
+	"ChatWire/constants"
+	"ChatWire/disc"
+	"ChatWire/glob"
+	"ChatWire/panel"
+)
+
+// WebPanelLink sends a temporary access link to the requester.
+func WebPanelLink(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
+	if !(disc.CheckModerator(i) || disc.CheckAdmin(i)) {
+		disc.InteractionEphemeralResponse(i, "Error", "You must be a moderator to use this command.")
+		return
+	}
+
+	token := panel.GenerateToken(i.Member.User.ID)
+	link := fmt.Sprintf("https://%v:%v/panel?token=%v", cfg.Global.Paths.URLs.Domain, cfg.Local.Port+constants.PanelPortOffset, token)
+	disc.InteractionEphemeralResponse(i, "Panel Link", link)
+}

--- a/commands/moderator/panel.go
+++ b/commands/moderator/panel.go
@@ -2,6 +2,7 @@ package moderator
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/bwmarrin/discordgo"
 
@@ -9,7 +10,6 @@ import (
 	"ChatWire/constants"
 	"ChatWire/disc"
 	"ChatWire/glob"
-	"ChatWire/panel"
 )
 
 // WebPanelLink sends a temporary access link to the requester.
@@ -19,7 +19,10 @@ func WebPanelLink(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 		return
 	}
 
-	token := panel.GenerateToken(i.Member.User.ID)
+	token := glob.RandomBase64String(20)
+	glob.PanelTokenLock.Lock()
+	glob.PanelTokens[token] = &glob.PanelTokenData{Token: token, DiscID: i.Member.User.ID, Time: time.Now().Unix()}
+	glob.PanelTokenLock.Unlock()
 	link := fmt.Sprintf("https://%v:%v/panel?token=%v", cfg.Global.Paths.URLs.Domain, cfg.Local.Port+constants.PanelPortOffset, token)
 	disc.InteractionEphemeralResponse(i, "Panel Link", link)
 }

--- a/constants/consts.go
+++ b/constants/consts.go
@@ -41,6 +41,9 @@ const (
 	// Default offset added to Factorio server port for RCON
 	RconPortOffset = 10000
 
+	// HTTPS status panel offset (server port + this value)
+	PanelPortOffset = RconPortOffset + 10000
+
 	// Minimum bytes required in level.dat0 to consider a save valid
 	LevelDatMinSize = 50 * 1024
 

--- a/disc/discUtils.go
+++ b/disc/discUtils.go
@@ -326,7 +326,11 @@ func InteractionEphemeralResponseColor(i *discordgo.InteractionCreate, title, me
 	glob.BootMessage = nil
 	glob.ResetUpdateMessage()
 
-	if DS == nil {
+	if DS == nil || i == nil {
+		return nil
+	}
+	if i.Member == nil || i.Member.User == nil {
+		cwlog.DoLogCW("EphemeralResponse nil user: " + title + "\n" + message)
 		return nil
 	}
 	cwlog.DoLogCW("EphemeralResponse:\n" + i.Member.User.Username + "\n" + title + "\n" + message)
@@ -356,7 +360,11 @@ func InteractionEphemeralFileResponse(i *discordgo.InteractionCreate, title, mes
 	glob.BootMessage = nil
 	glob.ResetUpdateMessage()
 
-	if DS == nil {
+	if DS == nil || i == nil {
+		return nil
+	}
+	if i.Member == nil || i.Member.User == nil {
+		cwlog.DoLogCW("EphemeralFileResponse nil user: " + title)
 		return nil
 	}
 	cwlog.DoLogCW("EphemeralFileResponse:\n" + i.Member.User.Username + "\n" + title)

--- a/glob/struct.go
+++ b/glob/struct.go
@@ -29,6 +29,13 @@ type PassData struct {
 	Time   int64
 }
 
+// PanelTokenData represents a temporary web panel token.
+type PanelTokenData struct {
+	Token  string
+	DiscID string
+	Time   int64
+}
+
 // VoteContainerData holds map vote data for the current campaign.
 type VoteContainerData struct {
 	Version string

--- a/glob/var.go
+++ b/glob/var.go
@@ -68,6 +68,10 @@ var (
 	PassList         map[string]*PassData
 	PasswordListLock sync.RWMutex
 
+	/* Web panel tokens */
+	PanelTokens    map[string]*PanelTokenData
+	PanelTokenLock sync.RWMutex
+
 	/* Player database status */
 	PlayerListUpdated       = false
 	PlayerListUpdatedLock   sync.Mutex

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ import (
 	"ChatWire/factUpdater"
 	"ChatWire/glob"
 	"ChatWire/modupdate"
+	"ChatWire/panel"
 	"ChatWire/support"
 )
 
@@ -76,6 +77,7 @@ func main() {
 	banlist.ReadBanFile(true)
 	fact.ReadVotes()
 	cwlog.StartGameLog()
+	panel.Start()
 	if !*glob.NoDiscord {
 		go support.MainLoops()
 		go support.HandleChat()
@@ -273,6 +275,7 @@ func initMaps() {
 	glob.ChatterSpamScore = make(map[string]int)
 	glob.PlayerList = make(map[string]*glob.PlayerData)
 	glob.PassList = make(map[string]*glob.PassData)
+	glob.PanelTokens = make(map[string]*glob.PanelTokenData)
 
 	/* Generate number to alpha map, used for auto port assignment starting at constants.RconPortOffset */
 	pos := constants.RconPortOffset

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -1,0 +1,100 @@
+package panel
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"html/template"
+	"math/big"
+	"net/http"
+	"time"
+
+	"ChatWire/cfg"
+	"ChatWire/constants"
+	"ChatWire/cwlog"
+	"ChatWire/fact"
+	"ChatWire/glob"
+)
+
+var panelHTML = `<!DOCTYPE html>
+<html><head><title>ChatWire Status</title></head>
+<body>
+<h2>ChatWire Status</h2>
+<p>Factorio version: {{.Factorio}}</p>
+<p>Players online: {{.Players}}</p>
+<p>Game time: {{.Gametime}}</p>
+</body></html>`
+
+type panelData struct {
+	Factorio string
+	Players  int
+	Gametime string
+}
+
+// Start runs the HTTPS status panel server.
+func Start() {
+	http.HandleFunc("/panel", handlePanel)
+	addr := fmt.Sprintf(":%v", cfg.Local.Port+constants.PanelPortOffset)
+	go func() {
+		cert, err := generateCert()
+		if err != nil {
+			cwlog.DoLogCW("Panel TLS error: %v", err)
+			return
+		}
+		srv := &http.Server{Addr: addr, TLSConfig: &tls.Config{Certificates: []tls.Certificate{cert}}}
+		cwlog.DoLogCW("Panel server listening on %v", addr)
+		if err := srv.ListenAndServeTLS("", ""); err != nil {
+			cwlog.DoLogCW("Panel server error: %v", err)
+		}
+	}()
+}
+
+// GenerateToken creates a temporary token for web access.
+func GenerateToken(id string) string {
+	token := glob.RandomBase64String(20)
+	glob.PanelTokenLock.Lock()
+	glob.PanelTokens[token] = &glob.PanelTokenData{Token: token, DiscID: id, Time: time.Now().Unix()}
+	glob.PanelTokenLock.Unlock()
+	return token
+}
+
+func handlePanel(w http.ResponseWriter, r *http.Request) {
+	tok := r.URL.Query().Get("token")
+	if tok == "" {
+		http.Error(w, "token required", http.StatusUnauthorized)
+		return
+	}
+	glob.PanelTokenLock.Lock()
+	_, ok := glob.PanelTokens[tok]
+	if ok {
+		delete(glob.PanelTokens, tok)
+	}
+	glob.PanelTokenLock.Unlock()
+	if !ok {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+	t := template.Must(template.New("panel").Parse(panelHTML))
+	pd := panelData{Factorio: fact.FactorioVersion, Players: fact.NumPlayers, Gametime: fact.GametimeString}
+	_ = t.Execute(w, pd)
+}
+
+func generateCert() (tls.Certificate, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	tpl := x509.Certificate{SerialNumber: big.NewInt(1), Subject: pkix.Name{Organization: []string{"ChatWire"}},
+		NotBefore: time.Now().Add(-time.Hour), NotAfter: time.Now().Add(24 * time.Hour), DNSNames: []string{cfg.Global.Paths.URLs.Domain}, BasicConstraintsValid: true}
+	der, err := x509.CreateCertificate(rand.Reader, &tpl, &tpl, &priv.PublicKey, priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	return tls.X509KeyPair(certPEM, keyPEM)
+}

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -228,6 +228,26 @@ func MainLoops() {
 	}()
 
 	/********************************
+	 * Delete expired panel tokens
+	 ********************************/
+	go func() {
+
+		for glob.ServerRunning {
+			time.Sleep(1 * time.Minute)
+
+			t := time.Now()
+
+			glob.PanelTokenLock.Lock()
+			for k, tok := range glob.PanelTokens {
+				if (t.Unix() - tok.Time) > constants.PassExpireSec {
+					delete(glob.PanelTokens, k)
+				}
+			}
+			glob.PanelTokenLock.Unlock()
+		}
+	}()
+
+	/********************************
 	 * Save database, if marked dirty
 	 ********************************/
 	go func() {


### PR DESCRIPTION
## Summary
- implement panel server with temporary token auth
- clean up expired panel tokens
- provide `/web-panel` moderator command for link
- start panel server on launch
- define `PanelPortOffset` constant

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844603219f8832aa63e85f4f4121b02