### PR TITLE
Add moderator audit logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /log/
+/audit-log/
 cw-local-config.json
 ChatWire
 cw.lock

--- a/commands/util.go
+++ b/commands/util.go
@@ -86,6 +86,7 @@ func SlashCommand(unused *discordgo.Session, i *discordgo.InteractionCreate) {
 							options = append(options, o.Name)
 						}
 						cwlog.DoLogCW("%s: ADMIN COMMAND: %s: %v", i.Member.User.Username, data.Name, strings.Join(options, ", "))
+						cwlog.DoLogAudit("%s: ADMIN COMMAND: %s: %v", i.Member.User.Username, data.Name, strings.Join(options, ", "))
 						return
 					} else {
 						disc.InteractionEphemeralResponse(i, "Error", "You must be a admin to use this command.")
@@ -95,6 +96,7 @@ func SlashCommand(unused *discordgo.Session, i *discordgo.InteractionCreate) {
 				} else if c.ModeratorOnly {
 					if disc.CheckModerator(i) || disc.CheckAdmin(i) {
 						cwlog.DoLogCW("%s: MOD COMMAND: %s", i.Member.User.Username, data.Name)
+						cwlog.DoLogAudit("%s: MOD COMMAND: %s", i.Member.User.Username, data.Name)
 						runCommand(&c, i)
 						return
 					} else {

--- a/cwlog/cwLog.go
+++ b/cwlog/cwLog.go
@@ -36,6 +36,32 @@ func DoLogCW(format string, args ...interface{}) {
 	}
 }
 
+/* Audit log for moderator/admin actions */
+func DoLogAudit(format string, args ...interface{}) {
+	if glob.AuditLogDesc == nil {
+		return
+	}
+
+	ctime := time.Now()
+	_, filename, line, _ := runtime.Caller(1)
+
+	var text string
+	if len(args) == 0 {
+		text = format
+	} else {
+		text = fmt.Sprintf(format, append([]interface{}(nil), args...)...)
+	}
+
+	date := fmt.Sprintf("%2v:%2v.%2v", ctime.Hour(), ctime.Minute(), ctime.Second())
+	buf := fmt.Sprintf("%v: %15v:%5v: %v\n", date, filepath.Base(filename), line, text)
+	_, err := glob.AuditLogDesc.WriteString(buf)
+	if err != nil {
+		fmt.Println("DoLogAudit: WriteString failure")
+		glob.AuditLogDesc = nil
+		return
+	}
+}
+
 /* Game log */
 func DoLogGame(format string, args ...interface{}) {
 	if glob.GameLogDesc == nil {
@@ -133,6 +159,44 @@ func StartCWLog() {
 
 }
 
+/* Prep everything for the audit log */
+func StartAuditLog() {
+
+	t := time.Now().UTC()
+
+	/* Create our log file names */
+	oldName := glob.AuditLogName
+	glob.AuditLogName = fmt.Sprintf("audit-log/audit-%v-%v-%v.log", t.Day(), t.Month(), t.Year())
+
+	/* Make log directory */
+	errr := os.MkdirAll("audit-log", os.ModePerm)
+	if errr != nil {
+		fmt.Print(errr.Error())
+		return
+	}
+
+	/* Open log files */
+	adesc, errb := os.OpenFile(glob.AuditLogName, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+
+	/* Handle file errors */
+	if errb != nil {
+		fmt.Printf("An error occurred when attempting to create audit log. Details: %s", errb)
+		return
+	}
+
+	if glob.AuditLogDesc != nil {
+		DoLogAudit("Rotating log.")
+		glob.AuditLogDesc.Close()
+		if fi, err := os.Stat(oldName); err == nil && fi.Size() == 0 {
+			_ = os.Remove(oldName)
+		}
+	}
+
+	/* Save descriptors, open/closed elsewhere */
+	glob.AuditLogDesc = adesc
+
+}
+
 func AutoRotateLogs() {
 	//Rotate when date changes
 	go func() {
@@ -143,6 +207,7 @@ func AutoRotateLogs() {
 				startDay = currentDay
 				StartCWLog()
 				StartGameLog()
+				StartAuditLog()
 			}
 			time.Sleep(time.Second)
 		}

--- a/fact/util.go
+++ b/fact/util.go
@@ -1201,6 +1201,10 @@ func DoExit(delay bool) {
 	cwlog.DoLogCW("Closing log files.")
 	glob.GameLogDesc.Close()
 	glob.CWLogDesc.Close()
+	glob.AuditLogDesc.Close()
+	if fi, err := os.Stat(glob.AuditLogName); err == nil && fi.Size() == 0 {
+		_ = os.Remove(glob.AuditLogName)
+	}
 
 	_ = os.Remove("cw.lock")
 	/* Logs are closed, don't report */

--- a/glob/var.go
+++ b/glob/var.go
@@ -46,10 +46,12 @@ var (
 	SoftModVersion = constants.Unknown
 
 	/* Log data */
-	GameLogName = ""
-	CWLogName   = ""
-	GameLogDesc *os.File
-	CWLogDesc   *os.File
+	GameLogName  = ""
+	CWLogName    = ""
+	AuditLogName = ""
+	GameLogDesc  *os.File
+	CWLogDesc    *os.File
+	AuditLogDesc *os.File
 
 	/* CW reboot */
 	DoRebootCW = false

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ func main() {
 
 	/* Start cw logs */
 	cwlog.StartCWLog()
+	cwlog.StartAuditLog()
 	cwlog.AutoRotateLogs()
 	cwlog.DoLogCW("\n Starting %v Version: %v", constants.ProgName, constants.Version)
 

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -607,6 +607,14 @@ func MainLoops() {
 				cwlog.DoLogCW("CWLog file was deleted, recreated.")
 			}
 
+			if _, err = os.Stat(glob.AuditLogName); err != nil {
+
+				glob.AuditLogDesc.Close()
+				glob.AuditLogDesc = nil
+				cwlog.StartAuditLog()
+				cwlog.DoLogAudit("Audit log file was deleted, recreated.")
+			}
+
 			if _, err = os.Stat(glob.GameLogName); err != nil {
 				glob.GameLogDesc.Close()
 				glob.GameLogDesc = nil


### PR DESCRIPTION
## Summary
- track moderator/admin actions in a new audit log
- rotate/recreate the audit log like the other logs
- start the audit log at startup
- keep audit logs in `audit-log/` and remove empty logs on rotation
- remove empty audit log file on shutdown

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844662d11e8832ab2bf9b48c579d9b2