### PR TITLE
Add audit logging for CMD/AUDIT stdout

### DIFF
--- a/support/pipeHandle.go
+++ b/support/pipeHandle.go
@@ -1221,6 +1221,19 @@ func handleCmdMsg(input *handleData) bool {
 		!strings.Contains(input.line, "/whitelist") &&
 		!strings.Contains(input.line, "/online") {
 		cwlog.DoLogGame(input.line)
+		cwlog.DoLogAudit(input.line)
+		return true
+	}
+	return false
+}
+
+func handleAuditMsg(input *handleData) bool {
+	/******************
+	 * AUDIT LOGGING
+	 ******************/
+	if strings.HasPrefix(input.line, "[AUDIT]") {
+		cwlog.DoLogGame(input.line)
+		cwlog.DoLogAudit(input.line)
 		return true
 	}
 	return false

--- a/support/pipeParse.go
+++ b/support/pipeParse.go
@@ -37,6 +37,7 @@ var noChatHandles = []funcList{
 
 var softModHandles = []funcList{
 	{function: handleCmdMsg},
+	{function: handleAuditMsg},
 	{function: handleActMsg},
 	{function: handleOnlineMsg},
 	{function: handleSoftModMsg},


### PR DESCRIPTION
## Summary
- log `[CMD]` and `[AUDIT]` lines from Factorio stdout to the audit log

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684471628560832ab66eeca6e12ec334