### PR TITLE
Expand control panel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,11 @@ go build
 ./ChatWire
 ```
 Ensure the generated configuration files contain your Discord token, application ID, guild ID and channel ID, along with Factorio credentials.
+
+### Web Control Panel
+
+Moderators can generate a temporary token with the `/web-panel` command. The control panel exposes
+server information similar to the `/info` command such as versions, uptime, next map reset and
+player statistics. It also provides buttons for common moderator actions like starting or stopping
+Factorio, synchronising mods or updating the game. Open the link provided by `/web-panel` in a web
+browser and supply the token as a query parameter.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Ensure the generated configuration files contain your Discord token, application
 ### Web Control Panel
 
 Moderators can generate a temporary token with the `/web-panel` command. The control panel exposes
-server information similar to the `/info` command such as versions, uptime, next map reset and
-player statistics. It also provides buttons for common moderator actions like starting or stopping
-Factorio, synchronising mods or updating the game. Open the link provided by `/web-panel` in a web
-browser and supply the token as a query parameter.
+information from the `/info` command such as versions, uptime, next map reset and player statistics.
+It provides buttons for common moderator actions like starting or stopping Factorio, synchronising
+mods or updating the game. Additional forms allow running arbitrary RCON commands and loading a
+specific save with the change map action. Open the link provided by `/web-panel` in a web browser
+and supply the token as a query parameter.


### PR DESCRIPTION
## Summary
- expand information in the web control panel
- document the control panel in README

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684484b558a8832aa2d5db1b30005099