### PR TITLE
Expand control panel info

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,13 @@ go build
 ./ChatWire
 ```
 Ensure the generated configuration files contain your Discord token, application ID, guild ID and channel ID, along with Factorio credentials.
+
+### Web Control Panel
+
+Moderators can generate a temporary token with the `/web-panel` command. The control panel exposes
+information from the `/info` command such as versions, uptime, next map reset and player statistics.
+It provides buttons for common moderator actions like starting or stopping Factorio, synchronising
+mods or updating the game. A map section lists the most recent autosaves and lets you load one with
+a single click or supply your own file name. Another form allows running arbitrary RCON commands.
+The page is rendered in a dark theme styled similarly to the public staff documentation. Open the
+link provided by `/web-panel` in a web browser and supply the token as a query parameter.


### PR DESCRIPTION
## Summary
- expand information in the web control panel
- allow moderator rcon commands and changing maps via the panel
- document the expanded panel in README
- make panel match the dark theme used in M45 documentation

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684484b558a8832aa2d5db1b30005099