### PR TITLE
Improve moderator panel layout

### DIFF
--- a/commands/list.go
+++ b/commands/list.go
@@ -12,3 +12,8 @@ func ListModAdminCommands() []glob.CommandData {
 	}
 	return out
 }
+
+// ListAllCommands returns all registered slash commands.
+func ListAllCommands() []glob.CommandData {
+	return cmds
+}


### PR DESCRIPTION
## Summary
- add helper to list all Discord commands
- style buttons with a red theme and fixed grids
- add tooltip info and command listing to panel
- show 4x4 grid of autosaves with age info

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68449c1522e0832a95de96bda483e191