### PR TITLE
Fix mod commands grid

### DIFF
--- a/commands/moderator/panel.go
+++ b/commands/moderator/panel.go
@@ -28,5 +28,21 @@ func WebPanelLink(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 		dom = "127.0.0.1"
 	}
 	link := fmt.Sprintf("https://%v:%v/panel?token=%v", dom, cfg.Local.Port+constants.PanelPortOffset, token)
-	disc.InteractionEphemeralResponse(i, "Panel Link", link)
+
+	embed := &discordgo.MessageEmbed{
+		Title:       "Click here to open the moderator panel",
+		URL:         link,
+		Description: "Run the /web-panel command again to invalidate your token if it becomes public.",
+		Color:       glob.COLOR_WHITE,
+	}
+	embeds := []*discordgo.MessageEmbed{embed}
+	resp := &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{Embeds: embeds, Flags: discordgo.MessageFlagsEphemeral},
+	}
+	err := disc.DS.InteractionRespond(i.Interaction, resp)
+	if err != nil {
+		newResp := &discordgo.WebhookEdit{Embeds: &embeds}
+		disc.DS.InteractionResponseEdit(i.Interaction, newResp)
+	}
 }

--- a/constants/consts.go
+++ b/constants/consts.go
@@ -13,6 +13,7 @@ const (
 	MaxNameLength      = 64
 	MaxBanReasonLength = 1024
 	PassExpireSec      = 5 * 60
+	PanelTokenLimitSec = 30 * 60
 
 	/* ChatWire files */
 	CWGlobalConfig      = "../cw-global-config.json"

--- a/glob/struct.go
+++ b/glob/struct.go
@@ -35,6 +35,7 @@ type PanelTokenData struct {
 	Name   string
 	DiscID string
 	Time   int64
+	Orig   int64
 }
 
 // VoteContainerData holds map vote data for the current campaign.

--- a/glob/struct.go
+++ b/glob/struct.go
@@ -36,6 +36,7 @@ type PanelTokenData struct {
 	DiscID string
 	Time   int64
 	Orig   int64
+	IP     string
 }
 
 // VoteContainerData holds map vote data for the current campaign.

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -144,6 +144,7 @@ var panelHTML = `<!DOCTYPE html>
     }
     .button-grid form {
         margin: 0;
+        width: 100%;
     }
     .button-grid button {
         display: flex;
@@ -157,6 +158,9 @@ var panelHTML = `<!DOCTYPE html>
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
         gap: var(--gap);
+    }
+    .save-grid form {
+        width: 100%;
     }
     .save-grid button {
         display: flex;

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -133,7 +133,10 @@ var panelHTML = `<!DOCTYPE html>
         max-width: 80%;
         min-width: 20rem;
     }
-    .banner {
+.banner {
+        position: sticky;
+        top: 0;
+        z-index: 1200;
         display: flex;
         align-items: center;
         gap: 0.4rem;
@@ -143,6 +146,13 @@ var panelHTML = `<!DOCTYPE html>
         border-radius: var(--radius);
         box-shadow: var(--shadow);
         margin-bottom: var(--gap);
+        outline: 1px solid #ffffff;
+    }
+    .panel-id {
+        font-weight: bold;
+        background: var(--surface);
+        padding: 0 0.4rem;
+        border-radius: var(--radius);
     }
     .confirm-overlay {
         position: fixed;
@@ -162,6 +172,8 @@ var panelHTML = `<!DOCTYPE html>
         font-size: 1.2rem;
         border: 2px solid black;
         outline: 2px solid #ffeb3b;
+        max-width: 34rem;
+        width: 90%;
     }
     .confirm-title {
         display: flex;
@@ -186,7 +198,7 @@ var panelHTML = `<!DOCTYPE html>
     }
     .confirm-buttons {
         display: flex;
-        justify-content: center;
+        justify-content: space-between;
         gap: var(--gap);
         margin-top: var(--gap);
     }
@@ -194,6 +206,7 @@ var panelHTML = `<!DOCTYPE html>
         width: auto;
         font-size: 1.5rem;
         padding: 0.6rem 1.2rem;
+        text-transform: capitalize;
     }
     .confirm-proceed { background: var(--positive); }
     .confirm-cancel { background: var(--accent); }
@@ -393,7 +406,7 @@ var panelHTML = `<!DOCTYPE html>
 </head>
 <body>
 <script>history.replaceState(null,"",location.pathname);</script>
-<div class="banner"><span class="material-icons">admin_panel_settings</span><span>Moderator Control Panel - {{.Callsign}} {{.ServerName}}</span></div>
+<div class="banner"><span class="material-icons">admin_panel_settings</span><span class="panel-id">Moderator Control Panel - {{.Callsign}}-{{.ServerName}}</span></div>
 <div class="areas">
 <div class="area section" id="info-area">
 <div class="section-header"><span class="material-icons">info</span><span class="title">Info</span><button class="minimize">&#8211;</button></div>
@@ -587,7 +600,7 @@ function confirmAction(msg){
 return new Promise(res=>{
 const ov=document.createElement('div');
 ov.className='confirm-overlay';
-ov.innerHTML='<div class="confirm-box"><div class="confirm-title"><span class="material-icons">warning</span><span>Confirm action</span></div><div class="confirm-message"><div class="action-box">'+msg+'</div></div><div class="confirm-buttons"><button class="confirm-proceed">proceed</button><button class="confirm-cancel">cancel</button></div></div>';
+ov.innerHTML='<div class="confirm-box"><div class="confirm-title"><span class="material-icons">warning</span><span>Confirm action</span></div><div class="confirm-message"><div class="action-box">'+msg+'</div></div><div class="confirm-buttons"><button class="confirm-cancel">cancel</button><button class="confirm-proceed">proceed</button></div></div>';
 ov.querySelector('.confirm-proceed').addEventListener('click',()=>{ov.remove();res(true);});
 ov.querySelector('.confirm-cancel').addEventListener('click',()=>{ov.remove();res(false);});
 document.body.appendChild(ov);

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -139,11 +139,19 @@ var panelHTML = `<!DOCTYPE html>
     }
     .button-grid {
         display: grid;
-        grid-template-columns: repeat(4, 1fr);
+        grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
         gap: var(--gap);
     }
     .button-grid form {
         margin: 0;
+    }
+    .button-grid button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
     .save-grid {
         display: grid;

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -211,7 +211,7 @@ var panelHTML = `<!DOCTYPE html>
     .confirm-proceed { background: var(--positive); }
     .confirm-cancel { background: var(--accent); }
     button {
-        background: var(--accent);
+        background: linear-gradient(to bottom, var(--accent), #4c0000);
         color: var(--text);
         border: 1px solid #ff3030;
         border-radius: var(--radius);
@@ -219,10 +219,12 @@ var panelHTML = `<!DOCTYPE html>
         margin: 0.2rem;
         cursor: pointer;
         width: 100%;
-        transition: filter 0.15s;
+        transition: filter 0.15s, box-shadow 0.15s;
+        box-shadow: 0 0.1rem 0.2rem rgba(0,0,0,0.5);
     }
     button:hover {
-        filter: brightness(1.1);
+        filter: brightness(1.3);
+        box-shadow: 0 0.2rem 0.4rem rgba(255,48,48,0.6);
     }
     .button-grid {
         display: grid;

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -170,12 +170,18 @@ var panelHTML = `<!DOCTYPE html>
         background: var(--accent);
         color: var(--text);
         font-size: 1.4rem;
-        margin: calc(-1.5 * var(--gap)) calc(-1.5 * var(--gap)) var(--gap) calc(-1.5 * var(--gap));
-        padding: 0.4rem;
+        margin: calc(-1.8 * var(--gap)) calc(-1.8 * var(--gap)) var(--gap) calc(-1.8 * var(--gap));
+        padding: 0.6rem;
         border-radius: var(--radius) var(--radius) 0 0;
     }
     .confirm-message {
         padding: var(--gap) 0;
+    }
+    .action-box {
+        border: 1px solid var(--accent);
+        background: var(--bg);
+        padding: var(--gap);
+        border-radius: var(--radius);
     }
     .confirm-buttons {
         display: flex;
@@ -183,7 +189,11 @@ var panelHTML = `<!DOCTYPE html>
         gap: var(--gap);
         margin-top: var(--gap);
     }
-    .confirm-box button { width: auto; }
+    .confirm-box button {
+        width: auto;
+        font-size: 1.5rem;
+        padding: 0.6rem 1.2rem;
+    }
     .confirm-proceed { background: var(--positive); }
     .confirm-cancel { background: var(--accent); }
     button {
@@ -575,7 +585,7 @@ function confirmAction(msg){
 return new Promise(res=>{
 const ov=document.createElement('div');
 ov.className='confirm-overlay';
-ov.innerHTML='<div class="confirm-box"><div class="confirm-title"><span class="material-icons">warning</span><span>Confirm action</span></div><div class="confirm-message">'+msg+'</div><div class="confirm-buttons"><button class="confirm-proceed">proceed</button><button class="confirm-cancel">cancel</button></div></div>';
+ov.innerHTML='<div class="confirm-box"><div class="confirm-title"><span class="material-icons">warning</span><span>Confirm action</span></div><div class="confirm-message"><div class="action-box">'+msg+'</div></div><div class="confirm-buttons"><button class="confirm-proceed">proceed</button><button class="confirm-cancel">cancel</button></div></div>';
 ov.querySelector('.confirm-proceed').addEventListener('click',()=>{ov.remove();res(true);});
 ov.querySelector('.confirm-cancel').addEventListener('click',()=>{ov.remove();res(false);});
 document.body.appendChild(ov);

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -155,8 +155,16 @@ var panelHTML = `<!DOCTYPE html>
     }
     .save-grid {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
         gap: var(--gap);
+    }
+    .save-grid button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
     .cmd-grid {
         display: grid;

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -154,10 +154,28 @@ var panelHTML = `<!DOCTYPE html>
     }
     .confirm-box {
         background: var(--surface);
-        padding: var(--gap);
+        padding: calc(var(--gap) * 1.5);
         border-radius: var(--radius);
         box-shadow: var(--shadow);
         text-align: center;
+        font-size: 1.2rem;
+        border: 2px solid black;
+        outline: 2px solid #ffeb3b;
+    }
+    .confirm-title {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.4rem;
+        background: var(--accent);
+        color: var(--text);
+        font-size: 1.4rem;
+        margin: calc(-1.5 * var(--gap)) calc(-1.5 * var(--gap)) var(--gap) calc(-1.5 * var(--gap));
+        padding: 0.4rem;
+        border-radius: var(--radius) var(--radius) 0 0;
+    }
+    .confirm-message {
+        padding: var(--gap) 0;
     }
     .confirm-buttons {
         display: flex;
@@ -553,7 +571,7 @@ function confirmAction(msg){
 return new Promise(res=>{
 const ov=document.createElement('div');
 ov.className='confirm-overlay';
-ov.innerHTML='<div class="confirm-box"><div>'+msg+'</div><div class="confirm-buttons"><button class="confirm-proceed">proceed</button><button class="confirm-cancel">cancel</button></div></div>';
+ov.innerHTML='<div class="confirm-box"><div class="confirm-title"><span class="material-icons">warning</span><span>Confirm action</span></div><div class="confirm-message">'+msg+'</div><div class="confirm-buttons"><button class="confirm-proceed">proceed</button><button class="confirm-cancel">cancel</button></div></div>';
 ov.querySelector('.confirm-proceed').addEventListener('click',()=>{ov.remove();res(true);});
 ov.querySelector('.confirm-cancel').addEventListener('click',()=>{ov.remove();res(false);});
 document.body.appendChild(ov);

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -44,7 +44,7 @@ var panelHTML = `<!DOCTYPE html>
     :root {
         --bg: #101010;
         --surface: #242424;
-        --accent: #8a0000;
+        --accent: #650000;
         --text: #ffffff;
         --positive: #0a8a0a;
         --radius: 0.4rem;
@@ -79,9 +79,9 @@ var panelHTML = `<!DOCTYPE html>
         padding: var(--gap);
         border: 1px solid var(--accent);
     }
-    #info-area { background: #303030; }
-    #command-area { background: #262626; }
-    #config-area { background: #1e1e1e; }
+    #info-area { background: #201010; }
+    #command-area { background: #181010; }
+    #config-area { background: #100808; }
     .section-header {
         display: flex;
         align-items: center;
@@ -392,6 +392,7 @@ var panelHTML = `<!DOCTYPE html>
     </style>
 </head>
 <body>
+<script>history.replaceState(null,"",location.pathname);</script>
 <div class="banner"><span class="material-icons">admin_panel_settings</span><span>Moderator Control Panel - {{.Callsign}} {{.ServerName}}</span></div>
 <div class="areas">
 <div class="area section" id="info-area">

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -190,6 +190,14 @@ var panelHTML = `<!DOCTYPE html>
     .confirm-message {
         padding: var(--gap) 0;
     }
+    .alert-icon {
+        text-align: center;
+        margin-bottom: var(--gap);
+    }
+    .alert-icon .material-icons {
+        font-size: 3.5rem;
+        color: #ffeb3b;
+    }
     .action-box {
         border: 1px solid var(--accent);
         background: var(--bg);
@@ -208,7 +216,10 @@ var panelHTML = `<!DOCTYPE html>
         padding: 0.6rem 1.2rem;
         text-transform: capitalize;
     }
-    .confirm-proceed { background: var(--positive); }
+    .confirm-proceed {
+        background: var(--positive);
+        border: 3px solid #ffffff !important;
+    }
     .confirm-cancel { background: var(--accent); }
     button {
         background: linear-gradient(to bottom, var(--accent), #4c0000);
@@ -602,7 +613,7 @@ function confirmAction(msg){
 return new Promise(res=>{
 const ov=document.createElement('div');
 ov.className='confirm-overlay';
-ov.innerHTML='<div class="confirm-box"><div class="confirm-title"><span class="material-icons">warning</span><span>Confirm action</span></div><div class="confirm-message"><div class="action-box">'+msg+'</div></div><div class="confirm-buttons"><button class="confirm-cancel">cancel</button><button class="confirm-proceed">proceed</button></div></div>';
+ov.innerHTML='<div class="confirm-box"><div class="confirm-title"><span class="material-icons">warning</span><span>Confirm action</span></div><div class="confirm-message"><div class="alert-icon"><span class="material-icons">warning</span></div><div class="action-box">'+msg+'</div></div><div class="confirm-buttons"><button class="confirm-cancel"><span class="material-icons">close</span> Cancel</button><button class="confirm-proceed"><span class="material-icons">check</span> Proceed</button></div></div>';
 ov.querySelector('.confirm-proceed').addEventListener('click',()=>{ov.remove();res(true);});
 ov.querySelector('.confirm-cancel').addEventListener('click',()=>{ov.remove();res(false);});
 document.body.appendChild(ov);

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -41,9 +41,9 @@ var panelHTML = `<!DOCTYPE html>
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <style>
     :root {
-        --bg: #131313;
-        --surface: #2b2b2b;
-        --accent: #b22020;
+        --bg: #101010;
+        --surface: #242424;
+        --accent: #8a0000;
         --text: #ffffff;
         --positive: #0a8a0a;
         --radius: 0.4rem;
@@ -78,9 +78,9 @@ var panelHTML = `<!DOCTYPE html>
         padding: var(--gap);
         border: 1px solid var(--accent);
     }
-    #info-area { background: #363636; }
-    #command-area { background: #2b2b2b; }
-    #config-area { background: #242424; }
+    #info-area { background: #303030; }
+    #command-area { background: #262626; }
+    #config-area { background: #1e1e1e; }
     .section-header {
         display: flex;
         align-items: center;
@@ -189,12 +189,16 @@ var panelHTML = `<!DOCTYPE html>
     button {
         background: var(--accent);
         color: var(--text);
-        border: none;
+        border: 1px solid #ff3030;
         border-radius: var(--radius);
         padding: 0.4rem;
         margin: 0.2rem;
         cursor: pointer;
         width: 100%;
+        transition: filter 0.15s;
+    }
+    button:hover {
+        filter: brightness(1.1);
     }
     .button-grid {
         display: grid;
@@ -322,7 +326,7 @@ var panelHTML = `<!DOCTYPE html>
         position: absolute;
         cursor: default;
         top: 0; left: 0; right: 0; bottom: 0;
-        background-color: #b22020;
+        background-color: var(--accent);
         transition: .4s;
         border-radius: 1.3rem;
     }

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -239,7 +239,7 @@ func MainLoops() {
 
 			glob.PanelTokenLock.Lock()
 			for k, tok := range glob.PanelTokens {
-				if (t.Unix() - tok.Time) > constants.PassExpireSec {
+				if (t.Unix()-tok.Time) > constants.PassExpireSec || (t.Unix()-tok.Orig) > constants.PanelTokenLimitSec {
 					delete(glob.PanelTokens, k)
 				}
 			}


### PR DESCRIPTION
## Summary
- keep moderator commands grid consistent with Discord commands section by using fixed-size columns and centering the buttons

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6844cdf6fce8832a973f5aec9e37651b