### PR TITLE
Improve info panel and command labels

### DIFF
--- a/panel/panel.go
+++ b/panel/panel.go
@@ -135,6 +135,7 @@ type panelData struct {
 	Mem           int
 	Reg           int
 	Vet           int
+	ModNames      []string
 	PlayHours     string
 	HoursEnabled  bool
 	Paused        bool
@@ -341,6 +342,8 @@ func handlePanel(w http.ResponseWriter, r *http.Request) {
 	for idx := range groups {
 		sort.Slice(groups[idx].Cmds, func(i, j int) bool { return groups[idx].Cmds[i].Label < groups[idx].Cmds[j].Label })
 	}
+	modNames := support.GetModFiles()
+	sort.Strings(modNames)
 	pd := panelData{ServerName: cfg.Local.Name, Callsign: strings.ToUpper(cfg.Local.Callsign),
 		CWVersion: constants.Version, Factorio: fact.FactorioVersion, SoftMod: softMod,
 		Players: fact.NumPlayers, Gametime: fact.GametimeString, SaveName: fact.LastSaveName,
@@ -348,6 +351,7 @@ func handlePanel(w http.ResponseWriter, r *http.Request) {
 		NextReset: nextReset, TimeTill: timeTill, ResetInterval: resetInterval,
 		Total: total, Mods: mods, Banned: ban, PlayHours: playHours, Paused: paused,
 		Token: tok, CmdGroups: groups, Saves: saves, Commands: cmdList, Info: buildInfoString(),
+		ModNames: modNames,
 		LocalCfg: buildCfgString(cfg.Local), GlobalCfg: buildCfgString(cfg.Global)}
 	_ = t.Execute(w, pd)
 }

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -85,9 +85,9 @@ var modCmdGroups = []panelCmdGroup{
 		Name: "ChatWire",
 		Cmds: []panelCmd{
 			{Cmd: "reboot-chatwire", Label: "Reboot ChatWire", Icon: "restart_alt"},
-			{Cmd: "queue-reboot", Label: "Queue Reboot", Icon: "schedule"},
-			{Cmd: "force-reboot", Label: "Force Reboot", Icon: "restart_alt"},
-			{Cmd: "queue-fact-reboot", Label: "Queue Fact Reboot", Icon: "schedule"},
+			{Cmd: "queue-reboot", Label: "Queue ChatWire Reboot", Icon: "schedule"},
+			{Cmd: "force-reboot", Label: "Force Reboot ChatWire", Icon: "restart_alt"},
+			{Cmd: "queue-fact-reboot", Label: "Queue Factorio Reboot", Icon: "schedule"},
 			{Cmd: "reload-config", Label: "Reload Config", Icon: "refresh"},
 		},
 	},
@@ -625,8 +625,11 @@ func buildInfoString() string {
 	ban += bCount
 	glob.PlayerListLock.RUnlock()
 	total := ban + mem + reg + vet + mod
-	add("Members/Regulars/Veterans", fmt.Sprintf("%d | %d | %d", mem, reg, vet))
-	add("Moderators/Banned", fmt.Sprintf("%d | %d", mod, ban))
+	add("Members", fmt.Sprintf("%d", mem))
+	add("Regulars", fmt.Sprintf("%d", reg))
+	add("Veterans", fmt.Sprintf("%d", vet))
+	add("Moderators", fmt.Sprintf("%d", mod))
+	add("Banned", fmt.Sprintf("%d", ban))
 	add("Total players", fmt.Sprintf("%d", total))
 
 	if fact.PausedTicks > 4 {

--- a/panel/template.html
+++ b/panel/template.html
@@ -292,14 +292,15 @@
         padding: 0.2rem 0.4rem;
     }
     .bool-display span {
-        flex: 0 0 40%;
+        flex: 0 0 60%;
+        max-width: 60%;
         text-align: right;
         word-break: break-word;
         min-width: 0;
     }
     .bool-display label {
-        flex: 0 0 60%;
-        max-width: 60%;
+        flex: 0 0 40%;
+        max-width: 40%;
         min-width: 0;
         display: flex;
         justify-content: flex-start;
@@ -311,14 +312,15 @@
         padding: 0.2rem 0.4rem;
     }
     .kv-display span {
-        flex: 0 0 40%;
+        flex: 0 0 60%;
+        max-width: 60%;
         text-align: right;
         word-break: break-word;
         min-width: 0;
     }
     .kv-display input {
-        flex: 0 1 60%;
-        max-width: 60%;
+        flex: 0 1 40%;
+        max-width: 40%;
         min-width: 0;
         text-align: left;
         box-sizing: border-box;

--- a/panel/template.html
+++ b/panel/template.html
@@ -295,10 +295,12 @@
         flex: 0 0 40%;
         text-align: right;
         word-break: break-word;
+        min-width: 0;
     }
     .bool-display label {
         flex: 0 0 60%;
         max-width: 60%;
+        min-width: 0;
         display: flex;
         justify-content: flex-start;
     }
@@ -312,10 +314,12 @@
         flex: 0 0 40%;
         text-align: right;
         word-break: break-word;
+        min-width: 0;
     }
     .kv-display input {
         flex: 0 1 60%;
         max-width: 60%;
+        min-width: 0;
         text-align: left;
         box-sizing: border-box;
         overflow: hidden;
@@ -430,6 +434,16 @@
 <pre>{{.Info}}</pre>
 </div>
 </div>
+<div class="card">
+<div class="card-header"><span class="material-icons">extension</span><span class="title">Installed Mods</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
+<div class="card-content">
+    <select multiple size="8" readonly>
+    {{range .ModNames}}
+        <option>{{.}}</option>
+    {{end}}
+    </select>
+</div>
+</div>
 </div>
 </div>
 
@@ -440,7 +454,9 @@
 <div class="card-header"><span class="material-icons">rule</span><span class="title">Moderator Commands</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
 {{range .CmdGroups}}
-<h4>{{.Name}}</h4>
+<div class="cfg-group">
+<div class="cfg-title">{{.Name}}</div>
+<div class="cfg-content">
 <div class="button-grid">
 {{range .Cmds}}
 <form method="POST" action="/action" class="cmd-form" data-desc="{{.Label}}">
@@ -449,6 +465,8 @@
     <button type="submit" title="{{.Cmd}}"><span class="material-icons">{{.Icon}}</span>{{.Label}}</button>
 </form>
 {{end}}
+</div>
+</div>
 </div>
 {{end}}
 </div>

--- a/panel/template.html
+++ b/panel/template.html
@@ -292,11 +292,13 @@
         padding: 0.2rem 0.4rem;
     }
     .bool-display span {
-        flex: 0 0 70%;
+        flex: 0 0 40%;
         text-align: right;
+        word-break: break-word;
     }
     .bool-display label {
-        flex: 0 0 auto;
+        flex: 0 0 60%;
+        max-width: 60%;
         display: flex;
         justify-content: flex-start;
     }
@@ -307,12 +309,13 @@
         padding: 0.2rem 0.4rem;
     }
     .kv-display span {
-        flex: 0 0 70%;
+        flex: 0 0 40%;
         text-align: right;
+        word-break: break-word;
     }
     .kv-display input {
-        flex: 0 1 30%;
-        max-width: 30%;
+        flex: 0 1 60%;
+        max-width: 60%;
         text-align: left;
         box-sizing: border-box;
         overflow: hidden;
@@ -418,9 +421,6 @@
 <div class="bool-display"><span>Paused</span><label class="switch"><input type="checkbox" disabled {{if .Paused}}checked{{end}}><span class="slider"></span></label></div>
 {{if ne .NextReset ""}}<div class="kv-display"><span>Next map reset</span><input class="value-box" type="text" readonly value="{{.NextReset}} ({{.TimeTill}})"></div>{{end}}
 {{if ne .ResetInterval ""}}<div class="kv-display"><span>Interval</span><input class="value-box" type="text" readonly value="{{.ResetInterval}}"></div>{{end}}
-<div class="kv-display"><span>Total players</span><input class="value-box" type="text" readonly value="{{.Total}}"></div>
-<div class="kv-display"><span>Members/Regulars/Veterans</span><input class="value-box" type="text" readonly value="{{.Mem}} | {{.Reg}} | {{.Vet}}"></div>
-<div class="kv-display"><span>Moderators/Banned</span><input class="value-box" type="text" readonly value="{{.Mods}} | {{.Banned}}"></div>
 </div>
 </div>
 
@@ -461,6 +461,7 @@
     <input type="hidden" name="token" value="{{$.Token}}">
     <input type="hidden" name="cmd" value="change-map">
     <select name="arg">
+        <option value="" disabled selected>click to choose a map</option>
         {{range .Saves}}
         <option value="{{.Name}}">{{.Name}} ({{.Age}})</option>
         {{end}}
@@ -522,7 +523,15 @@
     <input type="hidden" name="token" value="{{.Token}}">
     <input type="hidden" name="cmd" value="player-level">
     <input type="text" name="name" placeholder="player name">
-    <input type="number" name="level" placeholder="level">
+    <select name="level">
+        <option value="255">Moderator</option>
+        <option value="3">Veteran</option>
+        <option value="2">Regular</option>
+        <option value="1">Member</option>
+        <option value="0">New</option>
+        <option value="-1">Banned</option>
+        <option value="-255">Deleted</option>
+    </select>
     <input type="text" name="reason" placeholder="reason">
 <button type="submit">apply</button>
 </form>


### PR DESCRIPTION
## Summary
- tweak command labels for clarity
- split label/control width 40/60
- show level names in player level form
- add default text for map dropdown
- move player counts to server info

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6845222253a8832aa11e18539994631f