### PR TITLE
Fix panel layout and channel ID handling

### DIFF
--- a/cfg/localCfg.go
+++ b/cfg/localCfg.go
@@ -108,6 +108,7 @@ func ReadLCfg() bool {
 		cwlog.DoLogCW("ReadLCfg: os.Stat failed, auto-defaults generated.")
 		newcfg := createLCfg()
 		Local = newcfg
+		Local.Channel.ChatChannel = util.TrimPrefixIgnoreCase(strings.TrimSpace(Local.Channel.ChatChannel), "channel id:")
 		setLocalDefaults()
 		if !Local.Settings.AutoPause {
 			Local.Settings.AutoPause = true
@@ -129,6 +130,7 @@ func ReadLCfg() bool {
 		}
 
 		Local = newcfg
+		Local.Channel.ChatChannel = util.TrimPrefixIgnoreCase(strings.TrimSpace(Local.Channel.ChatChannel), "channel id:")
 		setLocalDefaults()
 
 		/* Automatic local defaults */

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -363,6 +363,7 @@ func handlePanel(w http.ResponseWriter, r *http.Request) {
 		"Callsign":         {},
 		"Port":             {},
 		"Channel ID":       {},
+		"Channel":          {},
 		"Last Backup Slot": {},
 	}
 	pd := panelData{ServerName: cfg.Local.Name, Callsign: strings.ToUpper(cfg.Local.Callsign),

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -357,6 +357,10 @@ func handlePanel(w http.ResponseWriter, r *http.Request) {
 		"Limit Open Hours": {},
 		"Open Hour":        {},
 		"Close Hour":       {},
+		"Callsign":         {},
+		"Port":             {},
+		"Channel ID":       {},
+		"Last Backup Slot": {},
 	}
 	pd := panelData{ServerName: cfg.Local.Name, Callsign: strings.ToUpper(cfg.Local.Callsign),
 		CWVersion: constants.Version, Factorio: fact.FactorioVersion, SoftMod: softMod,

--- a/panel/panel.go
+++ b/panel/panel.go
@@ -32,6 +32,7 @@ import (
 	"ChatWire/cwlog"
 	"ChatWire/fact"
 	"ChatWire/glob"
+	"ChatWire/modupdate"
 	"ChatWire/support"
 	"ChatWire/watcher"
 	"github.com/hako/durafmt"
@@ -86,7 +87,7 @@ var modCmdGroups = []panelCmdGroup{
 		Cmds: []panelCmd{
 			{Cmd: "reboot-chatwire", Label: "Reboot ChatWire", Icon: "restart_alt"},
 			{Cmd: "queue-reboot", Label: "Queue ChatWire Reboot", Icon: "schedule"},
-			{Cmd: "force-reboot", Label: "Force Reboot ChatWire", Icon: "restart_alt"},
+			{Cmd: "force-reboot", Label: "Force ChatWire Reboot", Icon: "restart_alt"},
 			{Cmd: "queue-fact-reboot", Label: "Queue Factorio Reboot", Icon: "schedule"},
 			{Cmd: "reload-config", Label: "Reload Config", Icon: "refresh"},
 		},
@@ -100,7 +101,7 @@ var modCmdGroups = []panelCmdGroup{
 			{Cmd: "update-factorio", Label: "Update Factorio", Icon: "update"},
 			{Cmd: "new-map", Label: "New Map", Icon: "create_new_folder"},
 			{Cmd: "archive-map", Label: "Archive Map", Icon: "archive"},
-			{Cmd: "map-reset", Label: "Map Reset", Icon: "map"},
+			{Cmd: "map-reset", Label: "Reset Map", Icon: "map"},
 		},
 	},
 	{
@@ -342,7 +343,11 @@ func handlePanel(w http.ResponseWriter, r *http.Request) {
 	for idx := range groups {
 		sort.Slice(groups[idx].Cmds, func(i, j int) bool { return groups[idx].Cmds[i].Label < groups[idx].Cmds[j].Label })
 	}
-	modNames := support.GetModFiles()
+	modFiles, _ := modupdate.GetModFiles()
+	var modNames []string
+	for _, m := range modFiles {
+		modNames = append(modNames, fmt.Sprintf("%s (%s)", m.Name, m.Version))
+	}
 	sort.Strings(modNames)
 	skip := map[string]struct{}{
 		"Next map reset":   {},

--- a/panel/template.html
+++ b/panel/template.html
@@ -361,6 +361,11 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
+    .kv-display select {
+        flex: 0 1 40%;
+        max-width: 40%;
+        min-width: 0;
+    }
     .value-box {
         border: 1px solid var(--accent);
         background: var(--bg);
@@ -507,12 +512,12 @@
 </div>
 </div>
 <div class="card">
-<div class="card-header"><span class="material-icons">schedule</span><span class="title">Set Play Hours</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
+<div class="card-header"><span class="material-icons">schedule</span><span class="title">Limit Play Hours</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
 <form method="POST" action="/action" class="cmd-form">
     <input type="hidden" name="token" value="{{.Token}}">
     <input type="hidden" name="cmd" value="config-hours">
-    <div class="bool-display"><span>enable</span><input type="checkbox" name="enabled" {{if .HoursEnabled}}checked{{end}}></div><br>
+    <div class="bool-display"><span>Enable Limits</span><input type="checkbox" name="enabled" {{if .HoursEnabled}}checked{{end}}></div><br>
     <select name="start">
         <option value="" disabled selected>start hour</option>
         <option>0</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option><option>6</option><option>7</option><option>8</option><option>9</option><option>10</option><option>11</option><option>12</option><option>13</option><option>14</option><option>15</option><option>16</option><option>17</option><option>18</option><option>19</option><option>20</option><option>21</option><option>22</option><option>23</option>
@@ -532,20 +537,18 @@
 <form method="POST" action="/action" class="cmd-form">
     <input type="hidden" name="token" value="{{.Token}}">
     <input type="hidden" name="cmd" value="set-schedule">
-    <select name="months">
+    <div class="kv-display"><span class="note">months</span><select name="months">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
         <option>8</option><option>9</option><option>10</option><option>11</option>
         <option>12</option>
-    </select>
-    <span class="note">months</span>
-    <select name="weeks">
+    </select></div>
+    <div class="kv-display"><span class="note">weeks</span><select name="weeks">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
         <option>8</option>
-    </select>
-    <span class="note">weeks</span>
-    <select name="days">
+    </select></div>
+    <div class="kv-display"><span class="note">days</span><select name="days">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
         <option>8</option><option>9</option><option>10</option><option>11</option>
@@ -554,17 +557,15 @@
         <option>20</option><option>21</option><option>22</option><option>23</option>
         <option>24</option><option>25</option><option>26</option><option>27</option>
         <option>28</option><option>29</option><option>30</option><option>31</option>
-    </select>
-    <span class="note">days</span>
-    <span class="note">hours</span>
-    <select name="hours">
+    </select></div>
+    <div class="kv-display"><span class="note">hours</span><select name="hours">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
         <option>8</option><option>9</option><option>10</option><option>11</option>
         <option>12</option><option>13</option><option>14</option><option>15</option>
         <option>16</option><option>17</option><option>18</option><option>19</option>
         <option>20</option><option>21</option><option>22</option><option>23</option>
-    </select>
+    </select></div>
     <input type="datetime-local" name="date">
     <p class="note">Use this to set a specific reset date and time.</p>
     <button type="submit">apply</button>

--- a/panel/template.html
+++ b/panel/template.html
@@ -259,13 +259,18 @@
         align-items: center;
         justify-content: center;
     }
-    .close {
+.close {
         background: none;
         border: none;
         color: inherit;
         cursor: pointer;
-        padding: 0 0.2rem;
+        padding: 0;
         font-size: 1rem;
+        width: 1.6rem;
+        height: 1.6rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
     input[type="text"] {
         width: 100%;
@@ -338,6 +343,14 @@
         font-size: 0.9rem;
         margin: 0.2rem 0;
         color: #ccc;
+    }
+    .schedule-date {
+        display: block;
+        margin: 0 auto 0.4rem auto;
+    }
+    .schedule-note {
+        text-align: center;
+        margin-bottom: 0.4rem;
     }
     .kv-display {
         display: flex;
@@ -566,8 +579,8 @@
         <option>16</option><option>17</option><option>18</option><option>19</option>
         <option>20</option><option>21</option><option>22</option><option>23</option>
     </select></div>
-    <input type="datetime-local" name="date">
-    <p class="note">Use this to set a specific reset date and time.</p>
+    <input type="datetime-local" name="date" class="schedule-date">
+    <p class="note schedule-note">Use this to set a specific reset date and time.</p>
     <button type="submit">apply</button>
 </form>
 <form method="POST" action="/action" class="cmd-form">

--- a/panel/template.html
+++ b/panel/template.html
@@ -298,12 +298,10 @@
         word-break: break-word;
         min-width: 0;
     }
-    .bool-display label {
+    .bool-display input {
         flex: 0 0 40%;
         max-width: 40%;
         min-width: 0;
-        display: flex;
-        justify-content: flex-start;
     }
     .kv-display {
         display: flex;
@@ -339,34 +337,6 @@
         text-decoration: none;
         display: inline-block;
     }
-    .switch {
-        position: relative;
-        display: inline-block;
-        width: 2.5rem;
-        height: 1.3rem;
-    }
-    .switch input { opacity: 0; width: 0; height: 0; }
-    .slider {
-        position: absolute;
-        cursor: default;
-        top: 0; left: 0; right: 0; bottom: 0;
-        background-color: var(--accent);
-        transition: .4s;
-        border-radius: 1.3rem;
-    }
-    .slider:before {
-        position: absolute;
-        content: "";
-        height: 1.1rem;
-        width: 1.1rem;
-        left: 0.1rem;
-        bottom: 0.1rem;
-        background-color: white;
-        transition: .4s;
-        border-radius: 50%;
-    }
-    .switch input:checked + .slider { background-color: #0a8a0a; }
-    .switch input:checked + .slider:before { transform: translateX(1.2rem); }
     .cfg-group {
         border: 1px solid var(--accent);
         border-radius: var(--radius);
@@ -424,7 +394,7 @@
 <div class="kv-display"><span>Factorio up-time</span><input class="value-box" type="text" readonly value="{{.FactUp}}"></div>
 <div class="kv-display"><span>UPS 10m/30m/1h</span><input class="value-box" type="text" readonly value="{{.UPS10}}/{{.UPS30}}/{{.UPS60}}"></div>
 {{if ne .PlayHours ""}}<div class="kv-display"><span>Play hours</span><input class="value-box" type="text" readonly value="{{.PlayHours}}"></div>{{end}}
-<div class="bool-display"><span>Paused</span><label class="switch"><input type="checkbox" disabled {{if .Paused}}checked{{end}}><span class="slider"></span></label></div>
+<div class="bool-display"><span>Paused</span><input type="checkbox" disabled {{if .Paused}}checked{{end}}></div>
 {{if ne .NextReset ""}}<div class="kv-display"><span>Next map reset</span><input class="value-box" type="text" readonly value="{{.NextReset}} ({{.TimeTill}})"></div>{{end}}
 {{if ne .ResetInterval ""}}<div class="kv-display"><span>Interval</span><input class="value-box" type="text" readonly value="{{.ResetInterval}}"></div>{{end}}
 </div>
@@ -439,7 +409,7 @@
 <div class="card">
 <div class="card-header"><span class="material-icons">extension</span><span class="title">Installed Mods</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
-    <select multiple size="8" readonly>
+    <select multiple size="{{len .ModNames}}" readonly>
     {{range .ModNames}}
         <option>{{.}}</option>
     {{end}}
@@ -509,7 +479,7 @@
 <form method="POST" action="/action" class="cmd-form">
     <input type="hidden" name="token" value="{{.Token}}">
     <input type="hidden" name="cmd" value="config-hours">
-    <div class="bool-display"><span>enable</span><label class="switch"><input type="checkbox" name="enabled" {{if .HoursEnabled}}checked{{end}}><span class="slider"></span></label></div><br>
+    <div class="bool-display"><span>enable</span><input type="checkbox" name="enabled" {{if .HoursEnabled}}checked{{end}}></div><br>
     <input type="number" name="start" min="0" max="23" placeholder="start hour">
     <input type="number" name="end" min="0" max="23" placeholder="end hour">
 <button type="submit">apply</button>
@@ -681,7 +651,7 @@ lines.forEach(l=>{
     if(v==='true' || v==='false'){
       const bd=document.createElement('div');
       bd.className='bool-display';
-      bd.innerHTML='<span>'+k+'</span><label class="switch"><input type="checkbox" disabled '+(v==='true'?'checked':'')+'><span class="slider"></span></label>';
+      bd.innerHTML='<span>'+k+'</span><input type="checkbox" disabled '+(v==='true'?'checked':'')+'>';
       content.appendChild(bd);
     }else{
       const div=document.createElement('div');

--- a/panel/template.html
+++ b/panel/template.html
@@ -303,6 +303,12 @@
         max-width: 40%;
         min-width: 0;
     }
+    .bool-display input[type="checkbox"] {
+        width: 1.3rem;
+        height: 1.3rem;
+        accent-color: var(--positive);
+        cursor: pointer;
+    }
     .kv-display {
         display: flex;
         align-items: center;

--- a/panel/template.html
+++ b/panel/template.html
@@ -299,8 +299,9 @@
         min-width: 0;
     }
     .bool-display input {
-        flex: 0 0 40%;
-        max-width: 40%;
+        flex: 0 0 auto;
+        width: auto;
+        max-width: none;
         min-width: 0;
     }
     .bool-display input[type="checkbox"] {
@@ -426,11 +427,18 @@
 <div class="kv-display"><span>Game time</span><input class="value-box" type="text" readonly value="{{.Gametime}}"></div>
 <div class="kv-display"><span>Last save</span><input class="value-box" type="text" readonly value="{{.SaveName}}"></div>
 <div class="kv-display"><span>Factorio up-time</span><input class="value-box" type="text" readonly value="{{.FactUp}}"></div>
-<div class="kv-display"><span>UPS 10m/30m/1h</span><input class="value-box" type="text" readonly value="{{.UPS10}}/{{.UPS30}}/{{.UPS60}}"></div>
+<div class="kv-display"><span>UPS 10m/30m/1h</span><input class="value-box" type="text" readonly value="{{.UPS}}"></div>
 {{if ne .PlayHours ""}}<div class="kv-display"><span>Play hours</span><input class="value-box" type="text" readonly value="{{.PlayHours}}"></div>{{end}}
 <div class="bool-display"><span>Paused</span><input type="checkbox" disabled {{if .Paused}}checked{{end}}></div>
-{{if ne .NextReset ""}}<div class="kv-display"><span>Next map reset</span><input class="value-box" type="text" readonly value="{{.NextReset}} ({{.TimeTill}})"></div>{{end}}
-{{if ne .ResetInterval ""}}<div class="kv-display"><span>Interval</span><input class="value-box" type="text" readonly value="{{.ResetInterval}}"></div>{{end}}
+</div>
+</div>
+
+<div class="card">
+<div class="card-header"><span class="material-icons">map</span><span class="title">Map</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
+<div class="card-content info-list">
+    {{if ne .NextReset ""}}<div class="kv-display"><span>Next map reset</span><input class="value-box" type="text" readonly value="{{.NextReset}}"></div>{{end}}
+    {{if ne .TimeTill ""}}<div class="kv-display"><span>Time till reset</span><input class="value-box" type="text" readonly value="{{.TimeTill}}"></div>{{end}}
+    {{if ne .ResetInterval ""}}<div class="kv-display"><span>Interval</span><input class="value-box" type="text" readonly value="{{.ResetInterval}}"></div>{{end}}
 </div>
 </div>
 
@@ -523,9 +531,37 @@
 <form method="POST" action="/action" class="cmd-form">
     <input type="hidden" name="token" value="{{.Token}}">
     <input type="hidden" name="cmd" value="set-schedule">
-    <input type="number" name="days" placeholder="days" min="0">
-    <input type="number" name="hours" placeholder="hours" min="0">
-    <input type="text" name="date" placeholder="YYYY-MM-DD HH-MM-SS">
+    <select name="months">
+        <option>0</option><option>1</option><option>2</option><option>3</option>
+        <option>4</option><option>5</option><option>6</option><option>7</option>
+        <option>8</option><option>9</option><option>10</option><option>11</option>
+        <option>12</option>
+    </select>
+    <select name="weeks">
+        <option>0</option><option>1</option><option>2</option><option>3</option>
+        <option>4</option><option>5</option><option>6</option><option>7</option>
+        <option>8</option>
+    </select>
+    <select name="days">
+        <option>0</option><option>1</option><option>2</option><option>3</option>
+        <option>4</option><option>5</option><option>6</option><option>7</option>
+        <option>8</option><option>9</option><option>10</option><option>11</option>
+        <option>12</option><option>13</option><option>14</option><option>15</option>
+        <option>16</option><option>17</option><option>18</option><option>19</option>
+        <option>20</option><option>21</option><option>22</option><option>23</option>
+        <option>24</option><option>25</option><option>26</option><option>27</option>
+        <option>28</option><option>29</option><option>30</option><option>31</option>
+    </select>
+    <select name="hours">
+        <option>0</option><option>1</option><option>2</option><option>3</option>
+        <option>4</option><option>5</option><option>6</option><option>7</option>
+        <option>8</option><option>9</option><option>10</option><option>11</option>
+        <option>12</option><option>13</option><option>14</option><option>15</option>
+        <option>16</option><option>17</option><option>18</option><option>19</option>
+        <option>20</option><option>21</option><option>22</option><option>23</option>
+    </select>
+    <input type="datetime-local" name="date">
+    <p class="note">Use this to set a specific reset date and time.</p>
     <button type="submit">apply</button>
 </form>
 <form method="POST" action="/action" class="cmd-form">

--- a/panel/template.html
+++ b/panel/template.html
@@ -304,10 +304,38 @@
         min-width: 0;
     }
     .bool-display input[type="checkbox"] {
-        width: 1.3rem;
-        height: 1.3rem;
-        accent-color: var(--positive);
+        appearance: none;
+        width: 1.2rem;
+        height: 1.2rem;
+        border: 2px solid var(--accent);
+        border-radius: 0.2rem;
+        background: var(--bg);
         cursor: pointer;
+        position: relative;
+    }
+    .bool-display input[type="checkbox"]:checked {
+        background: var(--positive);
+        border-color: var(--positive);
+    }
+    .bool-display input[type="checkbox"]::after {
+        content: '';
+        position: absolute;
+        left: 0.25rem;
+        top: 0.05rem;
+        width: 0.35rem;
+        height: 0.7rem;
+        border: solid var(--bg);
+        border-width: 0 0.2rem 0.2rem 0;
+        transform: rotate(45deg);
+        opacity: 0;
+    }
+    .bool-display input[type="checkbox"]:checked::after {
+        opacity: 1;
+    }
+    .note {
+        font-size: 0.9rem;
+        margin: 0.2rem 0;
+        color: #ccc;
     }
     .kv-display {
         display: flex;
@@ -412,16 +440,6 @@
 <pre>{{.Info}}</pre>
 </div>
 </div>
-<div class="card">
-<div class="card-header"><span class="material-icons">extension</span><span class="title">Installed Mods</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
-<div class="card-content">
-    <select multiple size="{{len .ModNames}}" readonly>
-    {{range .ModNames}}
-        <option>{{.}}</option>
-    {{end}}
-    </select>
-</div>
-</div>
 </div>
 </div>
 
@@ -486,8 +504,14 @@
     <input type="hidden" name="token" value="{{.Token}}">
     <input type="hidden" name="cmd" value="config-hours">
     <div class="bool-display"><span>enable</span><input type="checkbox" name="enabled" {{if .HoursEnabled}}checked{{end}}></div><br>
-    <input type="number" name="start" min="0" max="23" placeholder="start hour">
-    <input type="number" name="end" min="0" max="23" placeholder="end hour">
+    <select name="start">
+        <option value="" disabled selected>start hour</option>
+        <option>0</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option><option>6</option><option>7</option><option>8</option><option>9</option><option>10</option><option>11</option><option>12</option><option>13</option><option>14</option><option>15</option><option>16</option><option>17</option><option>18</option><option>19</option><option>20</option><option>21</option><option>22</option><option>23</option>
+    </select>
+    <select name="end">
+        <option value="" disabled selected>end hour</option>
+        <option>0</option><option>1</option><option>2</option><option>3</option><option>4</option><option>5</option><option>6</option><option>7</option><option>8</option><option>9</option><option>10</option><option>11</option><option>12</option><option>13</option><option>14</option><option>15</option><option>16</option><option>17</option><option>18</option><option>19</option><option>20</option><option>21</option><option>22</option><option>23</option>
+    </select>
 <button type="submit">apply</button>
 </form>
 </div>
@@ -520,14 +544,16 @@
     <input type="hidden" name="cmd" value="player-level">
     <input type="text" name="name" placeholder="player name">
     <select name="level">
-        <option value="255">Moderator</option>
-        <option value="3">Veteran</option>
-        <option value="2">Regular</option>
-        <option value="1">Member</option>
-        <option value="0">New</option>
+        <option value="" disabled selected>choose a level</option>
         <option value="-1">Banned</option>
         <option value="-255">Deleted</option>
+        <option value="0">New</option>
+        <option value="1">Member</option>
+        <option value="2">Regular</option>
+        <option value="3">Veteran</option>
+        <option value="255">Moderator</option>
     </select>
+    <p class="note">Please fill this out and include a log URL!</p>
     <input type="text" name="reason" placeholder="reason">
 <button type="submit">apply</button>
 </form>
@@ -559,6 +585,16 @@
 <div class="card-header"><span class="material-icons">build</span><span class="title">Local Configuration</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
 <pre>{{.LocalCfg}}</pre>
+</div>
+</div>
+<div class="card">
+<div class="card-header"><span class="material-icons">extension</span><span class="title">Installed Mods</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
+<div class="card-content">
+    <select multiple size="{{len .ModNames}}" readonly>
+    {{range .ModNames}}
+        <option>{{.}}</option>
+    {{end}}
+    </select>
 </div>
 </div>
 <div class="card collapsed">

--- a/panel/template.html
+++ b/panel/template.html
@@ -292,7 +292,9 @@
         padding: 0.2rem 0.4rem;
     }
     .bool-display span {
-        flex: 1 1 auto;
+        flex: 0 0 60%;
+        max-width: 60%;
+        text-align: right;
         word-break: break-word;
         min-width: 0;
     }
@@ -554,6 +556,7 @@
         <option>28</option><option>29</option><option>30</option><option>31</option>
     </select>
     <span class="note">days</span>
+    <span class="note">hours</span>
     <select name="hours">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
@@ -562,7 +565,6 @@
         <option>16</option><option>17</option><option>18</option><option>19</option>
         <option>20</option><option>21</option><option>22</option><option>23</option>
     </select>
-    <span class="note">hours</span>
     <input type="datetime-local" name="date">
     <p class="note">Use this to set a specific reset date and time.</p>
     <button type="submit">apply</button>

--- a/panel/template.html
+++ b/panel/template.html
@@ -292,13 +292,12 @@
         padding: 0.2rem 0.4rem;
     }
     .bool-display span {
-        flex: 0 0 60%;
-        max-width: 60%;
-        text-align: right;
+        flex: 1 1 auto;
         word-break: break-word;
         min-width: 0;
     }
     .bool-display input {
+        margin-left: auto;
         flex: 0 0 auto;
         width: auto;
         max-width: none;
@@ -537,11 +536,13 @@
         <option>8</option><option>9</option><option>10</option><option>11</option>
         <option>12</option>
     </select>
+    <span class="note">months</span>
     <select name="weeks">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
         <option>8</option>
     </select>
+    <span class="note">weeks</span>
     <select name="days">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
@@ -552,6 +553,7 @@
         <option>24</option><option>25</option><option>26</option><option>27</option>
         <option>28</option><option>29</option><option>30</option><option>31</option>
     </select>
+    <span class="note">days</span>
     <select name="hours">
         <option>0</option><option>1</option><option>2</option><option>3</option>
         <option>4</option><option>5</option><option>6</option><option>7</option>
@@ -560,6 +562,7 @@
         <option>16</option><option>17</option><option>18</option><option>19</option>
         <option>20</option><option>21</option><option>22</option><option>23</option>
     </select>
+    <span class="note">hours</span>
     <input type="datetime-local" name="date">
     <p class="note">Use this to set a specific reset date and time.</p>
     <button type="submit">apply</button>


### PR DESCRIPTION
## Summary
- replace stretched sliders with simple checkboxes
- show mod versions and auto-size installed-mods list
- trim `channel id:` prefix when reading local config
- tweak some command labels for clarity

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684529c1b568832a8cf7404619e0690a