### PR TITLE
Improve panel config layout

### DIFF
--- a/cfg/struct.go
+++ b/cfg/struct.go
@@ -158,26 +158,29 @@ type ResetInterval struct {
 type localOptions struct {
 	LocalDescription string `web:"Factorio Description"`
 
+	AutoStart  bool    `web:"Auto Boot"`
+	AutoUpdate bool    `web:"Auto Updates"`
+	ExpUpdates bool    `web:"Experimental Updates"`
+	ModUpdate  bool    `web:"Auto Mod Updates"`
+	Speed      float32 `web:"Game Speed"`
+
+	HideAutosaves bool `web:"Hide Autosaves"`
+	HideResearch  bool `web:"Hide Research"`
+
+	PlayHourEnable bool `web:"Limit Open Hours"`
+	PlayStartHour  int  `web:"Open Hour"`
+	PlayEndHour    int  `web:"Close Hour"`
+
 	ResetInterval ResetInterval `web:"Reset interval"`
 	NextReset     time.Time     `web:"Next map reset"`
 	ResetHour     int           `web:"Map Reset Hour"`
 	SkipReset     bool          `web:"Skip Map Reset"`
 
-	ResetPingRole  string `form:"-"`
-	PlayHourEnable bool   `web:"Limit Open Hours"`
-	PlayStartHour  int    `web:"Open Hour"`
-	PlayEndHour    int    `web:"Close Hour"`
+	ResetPingRole string `form:"-"`
 
-	AutoStart       bool    `web:"Auto Boot/Reboot Factorio"`
-	AutoUpdate      bool    `web:"Auto Factorio Updates"`
-	ExpUpdates      bool    `web:"Factorio Experimental Updates"`
-	HideAutosaves   bool    `web:"Hide Autosaves"`
-	HideResearch    bool    `web:"Hide Research on Discord"`
-	RegularsOnly    bool    `web:"Regulars, Veterans only"`
-	MembersOnly     bool    `web:"Members, Regulars, Veterans only"`
-	CustomWhitelist bool    `web:"Private whitelist"`
-	ModUpdate       bool    `web:"Auto update Factorio Mods"`
-	Speed           float32 `web:"Game Speed Factor"`
+	MembersOnly     bool `web:"-"`
+	RegularsOnly    bool `web:"-"`
+	CustomWhitelist bool `web:"Private Whitelist"`
 
 	Whitelist bool
 

--- a/panel/template.html
+++ b/panel/template.html
@@ -683,6 +683,12 @@
 <div class="card-header"><span class="material-icons">build</span><span class="title">Local Configuration</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
 <pre>{{.LocalCfg}}</pre>
+<form method="POST" action="/action" class="cmd-form" data-desc="Apply Config">
+    <input type="hidden" name="token" value="{{.Token}}">
+    <input type="hidden" name="cmd" value="apply-config">
+    <textarea name="cfg" rows="12" style="width:100%">{{.LocalJSON}}</textarea>
+    <button type="submit">apply</button>
+</form>
 </div>
 </div>
 <div class="card">

--- a/panel/template.html
+++ b/panel/template.html
@@ -572,6 +572,22 @@
 </div>
 
 <div class="card">
+<div class="card-header"><span class="material-icons">how_to_reg</span><span class="title">Access Level</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
+<div class="card-content">
+<form method="POST" action="/action" class="cmd-form">
+    <input type="hidden" name="token" value="{{.Token}}">
+    <input type="hidden" name="cmd" value="access-level">
+    <select name="level">
+        <option value="0" {{if eq .AccessLevel 0}}selected{{end}}>Open</option>
+        <option value="1" {{if eq .AccessLevel 1}}selected{{end}}>Members+</option>
+        <option value="2" {{if eq .AccessLevel 2}}selected{{end}}>Regulars+</option>
+    </select>
+    <button type="submit">apply</button>
+</form>
+</div>
+</div>
+
+<div class="card">
 <div class="card-header"><span class="material-icons">event</span><span class="title">Set Map Schedule</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
 <form method="POST" action="/action" class="cmd-form">


### PR DESCRIPTION
## Summary
- reorder config fields and shorten labels
- preserve struct order in panel output
- expose server access level setting in panel

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68461c3ae9b0832aa9e854149a4e2fc0