### PR TITLE
Enable panel config editing

### DIFF
--- a/panel/template.html
+++ b/panel/template.html
@@ -711,17 +711,21 @@
 </div>
 <script>
 document.querySelectorAll('.cmd-form').forEach(f=>{
-f.addEventListener('submit',async e=>{
-e.preventDefault();
-let desc=f.dataset.desc||f.querySelector('button').textContent.trim();
-const arg=f.querySelector('input[name="arg"],input[name="name"]');
-if(arg&&arg.value){desc+=' '+arg.value;}
-if(!(await confirmAction(desc)))return;
-const data=new FormData(f);
-const r=await fetch('/action',{method:'POST',body:data});
-const t=await r.text();
-showResponse(t);
-});
+  f.addEventListener('submit',async e=>{
+    e.preventDefault();
+    let desc=f.dataset.desc||f.querySelector('button').textContent.trim();
+    const arg=f.querySelector('input[name="arg"],input[name="name"]');
+    if(arg&&arg.value){desc+=' '+arg.value;}
+    if(!(await confirmAction(desc)))return;
+    if(f.id==='cfg-form'&&window.cfgObj){
+      const ta=f.querySelector('textarea[name="cfg"]');
+      ta.value=JSON.stringify(window.cfgObj,null,2);
+    }
+    const data=new FormData(f);
+    const r=await fetch('/action',{method:'POST',body:data});
+    const t=await r.text();
+    showResponse(t);
+  });
 });
 function confirmAction(msg){
 return new Promise(res=>{
@@ -885,17 +889,16 @@ document.querySelectorAll('.minimize').forEach(b=>{
     });
 });
 document.querySelectorAll('#info-area pre').forEach(formatCfg);
+var cfgObj;
 const cfgForm=document.getElementById('cfg-form');
 if(cfgForm){
   const cfgArea=document.getElementById('local-cfg-pre');
   const ta=cfgForm.querySelector('textarea[name="cfg"]');
-  let cfgObj={};
+  cfgObj={};
   try{cfgObj=JSON.parse(ta.value);}catch(e){}
+  window.cfgObj=cfgObj;
   cfgArea.textContent='';
   renderCfgEditor(cfgObj,cfgArea);
-  cfgForm.addEventListener('submit',()=>{
-    ta.value=JSON.stringify(cfgObj,null,2);
-  });
 }
 </script>
 </body></html>

--- a/panel/template.html
+++ b/panel/template.html
@@ -683,12 +683,10 @@
 <div class="card-header"><span class="material-icons">build</span><span class="title">Local Configuration</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
 <pre id="local-cfg-pre">{{.LocalCfg}}</pre>
-<form method="POST" action="/action" id="cfg-form" class="cmd-form" data-desc="Apply Config">
+<form id="cfg-form">
     <input type="hidden" name="token" value="{{.Token}}">
-    <input type="hidden" name="cmd" value="apply-config">
-    <textarea name="cfg" hidden>{{.LocalJSON}}</textarea>
-    <button type="submit">apply</button>
 </form>
+<textarea id="cfg-json" hidden>{{.LocalJSON}}</textarea>
 </div>
 </div>
 <div class="card">
@@ -766,6 +764,15 @@ function setCfgPath(obj,path,value){
   for(let i=0;i<path.length-1;i++)o=o[path[i]];
   o[path[path.length-1]]=value;
 }
+function sendCfgField(path,value){
+  const data=new FormData();
+  data.append('token', cfgForm.querySelector('input[name="token"]').value);
+  data.append('cmd','set-config-field');
+  data.append('path',path.join('.'));
+  data.append('value',value);
+  fetch('/action',{method:'POST',body:data})
+    .then(r=>r.text()).then(showResponse);
+}
 function renderCfgEditor(obj, container, path=[]){
   Object.entries(obj).forEach(([k,v])=>{
     const p=path.concat(k);
@@ -792,7 +799,10 @@ function renderCfgEditor(obj, container, path=[]){
         const input=document.createElement('input');
         input.type='checkbox';
         input.checked=v;
-        input.addEventListener('change',()=>setCfgPath(obj,p,input.checked));
+        input.addEventListener('change',()=>{
+          setCfgPath(obj,p,input.checked);
+          sendCfgField(p,input.checked?'true':'false');
+        });
         box.appendChild(input);
         bd.appendChild(sp);
         bd.appendChild(box);
@@ -805,7 +815,11 @@ function renderCfgEditor(obj, container, path=[]){
         input.className='value-box';
         input.type=typeof v==='number'?'number':'text';
         input.value=v;
-        input.addEventListener('input',()=>setCfgPath(obj,p,input.type==='number'?Number(input.value):input.value));
+        input.addEventListener('change',()=>{
+          const val=input.type==='number'?input.value:input.value;
+          setCfgPath(obj,p,input.type==='number'?Number(val):val);
+          sendCfgField(p,val);
+        });
         div.appendChild(input);
         container.appendChild(div);
       }
@@ -893,7 +907,7 @@ var cfgObj;
 const cfgForm=document.getElementById('cfg-form');
 if(cfgForm){
   const cfgArea=document.getElementById('local-cfg-pre');
-  const ta=cfgForm.querySelector('textarea[name="cfg"]');
+  const ta=document.getElementById('cfg-json');
   cfgObj={};
   try{cfgObj=JSON.parse(ta.value);}catch(e){}
   window.cfgObj=cfgObj;

--- a/panel/template.html
+++ b/panel/template.html
@@ -438,6 +438,9 @@
         padding: 0.4rem;
         white-space: normal;
     }
+    input.dirty {
+        box-shadow: 0 0 0 2px #ffeb3b;
+    }
     form { margin: 0; }
     </style>
 </head>
@@ -683,8 +686,9 @@
 <div class="card-header"><span class="material-icons">build</span><span class="title">Local Configuration</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
 <pre id="local-cfg-pre">{{.LocalCfg}}</pre>
-<form id="cfg-form">
+<form id="cfg-form" data-desc="Apply Config">
     <input type="hidden" name="token" value="{{.Token}}">
+    <button type="submit">apply</button>
 </form>
 <textarea id="cfg-json" hidden>{{.LocalJSON}}</textarea>
 </div>
@@ -761,21 +765,27 @@ function makeValueNode(v){
 }
 function setCfgPath(obj,path,value){
   let o=obj;
-  for(let i=0;i<path.length-1;i++)o=o[path[i]];
+  for(let i=0;i<path.length-1;i++){
+    if(!(path[i] in o))o[path[i]]={};
+    o=o[path[i]];
+  }
   o[path[path.length-1]]=value;
+}
+function getCfgPath(obj,path){
+  return path.reduce((o,p)=>o?o[p]:undefined,obj);
 }
 function sendCfgField(path,value){
   const data=new FormData();
   data.append('token', cfgForm.querySelector('input[name="token"]').value);
   data.append('cmd','set-config-field');
-  data.append('path',path.join('.'));
+  data.append('path',Array.isArray(path)?path.join('.') : path);
   data.append('value',value);
-  fetch('/action',{method:'POST',body:data})
-    .then(r=>r.text()).then(showResponse);
+  return fetch('/action',{method:'POST',body:data}).then(r=>r.text());
 }
 function renderCfgEditor(obj, container, path=[]){
   Object.entries(obj).forEach(([k,v])=>{
     const p=path.concat(k);
+    const key=p.join('.');
     if(v&&typeof v==='object'&&!Array.isArray(v)){
       const g=document.createElement('div');
       g.className='cfg-group';
@@ -799,9 +809,18 @@ function renderCfgEditor(obj, container, path=[]){
         const input=document.createElement('input');
         input.type='checkbox';
         input.checked=v;
+        cfgInputs[key]=input;
+        input.dataset.path=key;
         input.addEventListener('change',()=>{
-          setCfgPath(obj,p,input.checked);
-          sendCfgField(p,input.checked?'true':'false');
+          setCfgPath(cfgObj,p,input.checked);
+          const orig=getCfgPath(cfgOrig,p);
+          if(input.checked!==orig){
+            dirtyFields.set(key,input.checked?'true':'false');
+            input.classList.add('dirty');
+          }else{
+            dirtyFields.delete(key);
+            input.classList.remove('dirty');
+          }
         });
         box.appendChild(input);
         bd.appendChild(sp);
@@ -815,10 +834,19 @@ function renderCfgEditor(obj, container, path=[]){
         input.className='value-box';
         input.type=typeof v==='number'?'number':'text';
         input.value=v;
-        input.addEventListener('change',()=>{
-          const val=input.type==='number'?input.value:input.value;
-          setCfgPath(obj,p,input.type==='number'?Number(val):val);
-          sendCfgField(p,val);
+        cfgInputs[key]=input;
+        input.dataset.path=key;
+        input.addEventListener('input',()=>{
+          const val=input.type==='number'?Number(input.value):input.value;
+          setCfgPath(cfgObj,p,val);
+          const orig=getCfgPath(cfgOrig,p);
+          if(val!==orig){
+            dirtyFields.set(key,String(val));
+            input.classList.add('dirty');
+          }else{
+            dirtyFields.delete(key);
+            input.classList.remove('dirty');
+          }
         });
         div.appendChild(input);
         container.appendChild(div);
@@ -903,16 +931,31 @@ document.querySelectorAll('.minimize').forEach(b=>{
     });
 });
 document.querySelectorAll('#info-area pre').forEach(formatCfg);
-var cfgObj;
+var cfgObj,cfgOrig;
+const dirtyFields=new Map();
+const cfgInputs={};
 const cfgForm=document.getElementById('cfg-form');
 if(cfgForm){
   const cfgArea=document.getElementById('local-cfg-pre');
   const ta=document.getElementById('cfg-json');
-  cfgObj={};
-  try{cfgObj=JSON.parse(ta.value);}catch(e){}
+  cfgObj={}; cfgOrig={};
+  try{cfgObj=JSON.parse(ta.value);cfgOrig=JSON.parse(ta.value);}catch(e){}
   window.cfgObj=cfgObj;
   cfgArea.textContent='';
   renderCfgEditor(cfgObj,cfgArea);
+  cfgForm.addEventListener('submit',async e=>{
+    e.preventDefault();
+    if(!dirtyFields.size)return;
+    let desc=cfgForm.dataset.desc||'Apply Config';
+    if(!(await confirmAction(desc)))return;
+    for(const [path,val] of dirtyFields.entries()){
+      const t=await sendCfgField(path,val);
+      showResponse(t);
+      cfgInputs[path].classList.remove('dirty');
+      setCfgPath(cfgOrig,path.split('.'),getCfgPath(cfgObj,path.split('.')));
+    }
+    dirtyFields.clear();
+  });
 }
 </script>
 </body></html>

--- a/panel/template.html
+++ b/panel/template.html
@@ -682,11 +682,11 @@
 <div class="card">
 <div class="card-header"><span class="material-icons">build</span><span class="title">Local Configuration</span><button class="minimize"><span class="material-icons">horizontal_rule</span></button></div>
 <div class="card-content">
-<pre>{{.LocalCfg}}</pre>
-<form method="POST" action="/action" class="cmd-form" data-desc="Apply Config">
+<pre id="local-cfg-pre">{{.LocalCfg}}</pre>
+<form method="POST" action="/action" id="cfg-form" class="cmd-form" data-desc="Apply Config">
     <input type="hidden" name="token" value="{{.Token}}">
     <input type="hidden" name="cmd" value="apply-config">
-    <textarea name="cfg" rows="12" style="width:100%">{{.LocalJSON}}</textarea>
+    <textarea name="cfg" hidden>{{.LocalJSON}}</textarea>
     <button type="submit">apply</button>
 </form>
 </div>
@@ -756,6 +756,57 @@ function makeValueNode(v){
   i.className='value-box';
   i.value=v;
   return i;
+}
+function setCfgPath(obj,path,value){
+  let o=obj;
+  for(let i=0;i<path.length-1;i++)o=o[path[i]];
+  o[path[path.length-1]]=value;
+}
+function renderCfgEditor(obj, container, path=[]){
+  Object.entries(obj).forEach(([k,v])=>{
+    const p=path.concat(k);
+    if(v&&typeof v==='object'&&!Array.isArray(v)){
+      const g=document.createElement('div');
+      g.className='cfg-group';
+      const t=document.createElement('div');
+      t.className='cfg-title';
+      t.textContent=k;
+      g.appendChild(t);
+      const c=document.createElement('div');
+      c.className='cfg-content';
+      g.appendChild(c);
+      container.appendChild(g);
+      renderCfgEditor(v,c,p);
+    }else{
+      if(typeof v==='boolean'){
+        const bd=document.createElement('div');
+        bd.className='bool-display';
+        const sp=document.createElement('span');
+        sp.textContent=k;
+        const box=document.createElement('span');
+        box.className='bool-box';
+        const input=document.createElement('input');
+        input.type='checkbox';
+        input.checked=v;
+        input.addEventListener('change',()=>setCfgPath(obj,p,input.checked));
+        box.appendChild(input);
+        bd.appendChild(sp);
+        bd.appendChild(box);
+        container.appendChild(bd);
+      }else{
+        const div=document.createElement('div');
+        div.className='kv-display';
+        div.appendChild(document.createElement('span')).textContent=k;
+        const input=document.createElement('input');
+        input.className='value-box';
+        input.type=typeof v==='number'?'number':'text';
+        input.value=v;
+        input.addEventListener('input',()=>setCfgPath(obj,p,input.type==='number'?Number(input.value):input.value));
+        div.appendChild(input);
+        container.appendChild(div);
+      }
+    }
+  });
 }
 function formatCfg(pre){
 const lines=pre.textContent.split('\n');
@@ -833,6 +884,18 @@ document.querySelectorAll('.minimize').forEach(b=>{
         box.classList.toggle('collapsed');
     });
 });
-document.querySelectorAll('#config-area pre, #info-area pre').forEach(formatCfg);
+document.querySelectorAll('#info-area pre').forEach(formatCfg);
+const cfgForm=document.getElementById('cfg-form');
+if(cfgForm){
+  const cfgArea=document.getElementById('local-cfg-pre');
+  const ta=cfgForm.querySelector('textarea[name="cfg"]');
+  let cfgObj={};
+  try{cfgObj=JSON.parse(ta.value);}catch(e){}
+  cfgArea.textContent='';
+  renderCfgEditor(cfgObj,cfgArea);
+  cfgForm.addEventListener('submit',()=>{
+    ta.value=JSON.stringify(cfgObj,null,2);
+  });
+}
 </script>
 </body></html>


### PR DESCRIPTION
## Summary
- make local config section interactive
- submit updated JSON when Apply is used
- hide JSON textarea to avoid exposing raw config

## Testing
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_684622c406e8832a925344f3d47c2beb