### PR TITLE
Add Factorio agent and IPC client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ playerdb.json
 factorio.tar
 .VSCodeCounter
 .vscode
+agent/agent

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ Ensure the generated configuration files contain your Discord token, application
 
 ### Factorio Agent
 
-ChatWire can run Factorio through a small helper daemon. The agent listens on the
-Unix socket `/var/run/factorio-agent.sock` and understands a byte protocol:
+ChatWire can run Factorio through a small helper daemon. The agent listens on a
+Unix socket located next to the agent binary, typically `agent/factorio-agent.sock`, and understands a byte protocol:
 
 ```
 0x01 <args>\n  start Factorio

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ ChatWire can run Factorio through a small helper daemon. The agent listens on a
 Unix socket located next to the agent binary, typically `agent/factorio-agent.sock`, and understands a byte protocol:
 
 ```
-0x01 <args>\n  start Factorio
+0x01 <binary> <args>\n  start Factorio (binary path followed by arguments)
 0x02          stop Factorio
 0x03          query running status (returns 0x01 or 0x00)
 0x04 <line>\n write a command to stdin

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Ensure the generated configuration files contain your Discord token, application
 ### Factorio Agent
 
 ChatWire can run Factorio through a small helper daemon. The agent listens on a
-Unix socket located next to the agent binary, typically `agent/factorio-agent.sock`, and understands a byte protocol:
+Unix socket located next to the agent binary (e.g. `factorio-agent.sock`) and understands a byte protocol:
 
 ```
 0x01 <binary> <args>\n  start Factorio (binary path followed by arguments)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,23 @@ go build
 ```
 Ensure the generated configuration files contain your Discord token, application ID, guild ID and channel ID, along with Factorio credentials.
 
+### Factorio Agent
+
+ChatWire can run Factorio through a small helper daemon. The agent listens on the
+Unix socket `/var/run/factorio-agent.sock` and understands a byte protocol:
+
+```
+0x01 <args>\n  start Factorio
+0x02          stop Factorio
+0x03          query running status (returns 0x01 or 0x00)
+0x04 <line>\n write a command to stdin
+0x05          read buffered stdout terminated by NUL
+```
+
+Whenever new stdout lines are available the agent sends `0x02 0x06` once per
+second. An example systemd unit is available at `misc/factorio-agent.service`.
+Enable and start this service so ChatWire can communicate with the agent.
+
 ### Web Control Panel
 
 The panel server is disabled by default. Launch ChatWire with `-panel` to enable it. Moderators can generate a temporary token with the `/web-panel` command. The control panel exposes

--- a/agent/main.go
+++ b/agent/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"ChatWire/fact"
+)
+
+const socketPath = "/var/run/factorio-agent.sock"
+
+var (
+	procCmd  *exec.Cmd
+	procIn   io.WriteCloser
+	bufLock  sync.Mutex
+	outBuf   []string
+	connLock sync.Mutex
+	conns    = make(map[net.Conn]struct{})
+)
+
+func main() {
+	_ = os.Remove(socketPath)
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		panic(err)
+	}
+	go notifier()
+	for {
+		c, err := ln.Accept()
+		if err != nil {
+			continue
+		}
+		connLock.Lock()
+		conns[c] = struct{}{}
+		connLock.Unlock()
+		go handleConn(c)
+	}
+}
+
+func notifier() {
+	t := time.NewTicker(time.Second)
+	for range t.C {
+		bufLock.Lock()
+		has := len(outBuf) > 0
+		bufLock.Unlock()
+		if has {
+			connLock.Lock()
+			for c := range conns {
+				c.Write([]byte{0x02, 0x06})
+			}
+			connLock.Unlock()
+		}
+	}
+}
+
+func handleConn(c net.Conn) {
+	defer func() {
+		connLock.Lock()
+		delete(conns, c)
+		connLock.Unlock()
+		c.Close()
+	}()
+	r := bufio.NewReader(c)
+	for {
+		cmd, err := r.ReadByte()
+		if err != nil {
+			return
+		}
+		switch cmd {
+		case 0x01: // start
+			line, _ := r.ReadString('\n')
+			args := strings.Fields(strings.TrimSpace(line))
+			startFactorio(args)
+			c.Write([]byte{0x01})
+		case 0x02: // stop
+			stopFactorio()
+			c.Write([]byte{0x01})
+		case 0x03: // running?
+			b := byte(0)
+			if procCmd != nil && procCmd.Process != nil {
+				b = 1
+			}
+			c.Write([]byte{b})
+		case 0x04: // write
+			line, _ := r.ReadString('\n')
+			writeFactorio(strings.TrimRight(line, "\n"))
+			c.Write([]byte{0x01})
+		case 0x05: // read buffer
+			lines := readBuffer()
+			var buf bytes.Buffer
+			for _, l := range lines {
+				buf.WriteString(l)
+				buf.WriteByte('\n')
+			}
+			buf.WriteByte(0)
+			c.Write(buf.Bytes())
+		default:
+		}
+	}
+}
+
+func startFactorio(args []string) error {
+	if procCmd != nil {
+		return errors.New("running")
+	}
+	procCmd = exec.Command(fact.GetFactorioBinary(), args...)
+	stdout, err := procCmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	procIn, err = procCmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+	if err := procCmd.Start(); err != nil {
+		return err
+	}
+	go readStdout(stdout)
+	go func() {
+		procCmd.Wait()
+		procCmd = nil
+	}()
+	return nil
+}
+
+func readStdout(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		line := scanner.Text()
+		bufLock.Lock()
+		outBuf = append(outBuf, line)
+		bufLock.Unlock()
+	}
+}
+
+func stopFactorio() {
+	if procCmd == nil {
+		return
+	}
+	writeFactorio("/quit")
+	procCmd.Wait()
+	procCmd = nil
+}
+
+func writeFactorio(line string) {
+	if procIn != nil {
+		io.WriteString(procIn, line+"\n")
+	}
+}
+
+func readBuffer() []string {
+	bufLock.Lock()
+	defer bufLock.Unlock()
+	lines := append([]string(nil), outBuf...)
+	outBuf = outBuf[:0]
+	return lines
+}

--- a/agent/main.go
+++ b/agent/main.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"ChatWire/fact"
@@ -112,6 +113,7 @@ func startFactorio(args []string) error {
 		return errors.New("running")
 	}
 	procCmd = exec.Command(fact.GetFactorioBinary(), args...)
+	procCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	stdout, err := procCmd.StdoutPipe()
 	if err != nil {
 		return err
@@ -120,6 +122,7 @@ func startFactorio(args []string) error {
 	if err != nil {
 		return err
 	}
+	procCmd.Stderr = procCmd.Stdout
 	if err := procCmd.Start(); err != nil {
 		return err
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -46,7 +46,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	socketPath := filepath.Join(filepath.Dir(ex), "factorio-agent.sock")
+	socketPath := filepath.Join(filepath.Dir(ex), "../factorio-agent.sock")
 	_ = os.Remove(socketPath)
 	ln, err := net.Listen("unix", socketPath)
 	if err != nil {

--- a/agent/main.go
+++ b/agent/main.go
@@ -14,8 +14,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"ChatWire/fact"
 )
 
 // Agent command bytes. Notifications reuse cmdStop followed by notifyBuffered.
@@ -144,12 +142,15 @@ func startFactorio(args []string) error {
 	if procCmd != nil {
 		return errors.New("running")
 	}
-	log.Printf("launching Factorio: %v", args)
-	bin := fact.GetFactorioBinary()
+	if len(args) == 0 {
+		return errors.New("no binary path provided")
+	}
+	bin := args[0]
 	if !filepath.IsAbs(bin) {
 		bin = filepath.Join("..", bin)
 	}
-	procCmd = exec.Command(bin, args...)
+	log.Printf("launching Factorio: %s %v", bin, args[1:])
+	procCmd = exec.Command(bin, args[1:]...)
 	procCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	stdout, err := procCmd.StdoutPipe()
 	if err != nil {

--- a/commands/moderator/chatwire.go
+++ b/commands/moderator/chatwire.go
@@ -21,7 +21,7 @@ func ForceReboot(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 /* Reboot when server is empty */
 func QueReboot(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 
-	disc.InteractionEphemeralResponse(i, "Complete:", "Reboot has been queued. Server will reboot when map is unoccupied.")
+	disc.InteractionEphemeralResponse(i, "Complete:", "Reboot has been queued.")
 	fact.QueueReboot = true
 }
 
@@ -39,7 +39,7 @@ func RebootCW(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 
 	glob.DoRebootCW = true
 	glob.RelaunchThrottle = 0
-	fact.QuitFactorio("Server rebooting...")
+	//fact.QuitFactorio("Server rebooting...")
 }
 
 /* Reload config files */

--- a/commands/moderator/chatwire.go
+++ b/commands/moderator/chatwire.go
@@ -13,7 +13,7 @@ import (
 /* Reboots cw */
 func ForceReboot(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 
-	disc.InteractionEphemeralResponse(i, "Status:", "Force rebooting!")
+	disc.InteractionEphemeralResponse(i, "Status:", "Force rebooting ChatWire!")
 	glob.RelaunchThrottle = 0
 	fact.DoExit(false)
 }
@@ -21,8 +21,9 @@ func ForceReboot(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 /* Reboot when server is empty */
 func QueReboot(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 
-	disc.InteractionEphemeralResponse(i, "Complete:", "Reboot has been queued.")
-	fact.QueueReboot = true
+	disc.InteractionEphemeralResponse(i, "Complete:", "Chatwire will reboot.")
+	glob.RelaunchThrottle = 0
+	fact.DoExit(false)
 }
 
 /* Reboot when server is empty */
@@ -37,9 +38,9 @@ func RebootCW(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 
 	disc.InteractionEphemeralResponse(i, "Status:", "Rebooting ChatWire...")
 
-	glob.DoRebootCW = true
+	disc.InteractionEphemeralResponse(i, "Complete:", "Chatwire will reboot.")
 	glob.RelaunchThrottle = 0
-	//fact.QuitFactorio("Server rebooting...")
+	fact.DoExit(false)
 }
 
 /* Reload config files */

--- a/fact/confGen.go
+++ b/fact/confGen.go
@@ -192,35 +192,36 @@ func GenerateFactorioConfig() bool {
 		remoteConsole, err := rcon.Dial("localhost"+":"+portstr, glob.RCONPass)
 		if err != nil || remoteConsole == nil {
 			cwlog.DoLogCW("Error: `%v`\n", err)
-		}
+		} else {
 
-		_, err = remoteConsole.Write(c + " name " + servName)
-		if err != nil {
-			cwlog.DoLogCW(err.Error())
-		}
-		_, err = remoteConsole.Write(c + " description " + serverDescString)
-		if err != nil {
-			cwlog.DoLogCW(err.Error())
-		}
-		/* 		remoteConsole.Write(c + " max-players " + "0")
-		 * 		remoteConsole.Write(c + " visibility-public " + "true")
-		 * 		remoteConsole.Write(c + " visibility-steam " + "true")
-		 * 		remoteConsole.Write(c + " visibility-lan " + "false")
-		 * 		remoteConsole.Write(c + " require-user-verification " + "true")
-		 * 		remoteConsole.Write(c + " allow-commands " + "admins-only") */
-		_, err = remoteConsole.Write(c + " autosave-interval " + strconv.Itoa(autosave_interval))
-		if err != nil {
-			cwlog.DoLogCW(err.Error())
-		}
-		_, err = remoteConsole.Write(c + " afk-auto-kick " + strconv.Itoa(autokick))
-		if err != nil {
-			cwlog.DoLogCW(err.Error())
-		}
-		/* 		remoteConsole.Write(c + " only-admins-can-pause " + "true")
-		 * 		remoteConsole.Write(c + " autosave-only-on-server " + "true") */
-		err = remoteConsole.Close()
-		if err != nil {
-			cwlog.DoLogCW(err.Error())
+			_, err = remoteConsole.Write(c + " name " + servName)
+			if err != nil {
+				cwlog.DoLogCW(err.Error())
+			}
+			_, err = remoteConsole.Write(c + " description " + serverDescString)
+			if err != nil {
+				cwlog.DoLogCW(err.Error())
+			}
+			/* 		remoteConsole.Write(c + " max-players " + "0")
+			 * 		remoteConsole.Write(c + " visibility-public " + "true")
+			 * 		remoteConsole.Write(c + " visibility-steam " + "true")
+			 * 		remoteConsole.Write(c + " visibility-lan " + "false")
+			 * 		remoteConsole.Write(c + " require-user-verification " + "true")
+			 * 		remoteConsole.Write(c + " allow-commands " + "admins-only") */
+			_, err = remoteConsole.Write(c + " autosave-interval " + strconv.Itoa(autosave_interval))
+			if err != nil {
+				cwlog.DoLogCW(err.Error())
+			}
+			_, err = remoteConsole.Write(c + " afk-auto-kick " + strconv.Itoa(autokick))
+			if err != nil {
+				cwlog.DoLogCW(err.Error())
+			}
+			/* 		remoteConsole.Write(c + " only-admins-can-pause " + "true")
+			 * 		remoteConsole.Write(c + " autosave-only-on-server " + "true") */
+			err = remoteConsole.Close()
+			if err != nil {
+				cwlog.DoLogCW(err.Error())
+			}
 		}
 	}
 

--- a/fact/mapReset.go
+++ b/fact/mapReset.go
@@ -36,15 +36,6 @@ func getMapTypeNum(mapt string) int {
 	return -1
 }
 
-func getMapTypeName(num int) string {
-
-	numMaps := len(constants.MapTypes)
-	if num >= 0 && num < numMaps {
-		return constants.MapTypes[num]
-	}
-	return "Error"
-}
-
 /* Generate map */
 func Map_reset(doReport bool) {
 

--- a/fact/newCron.go
+++ b/fact/newCron.go
@@ -108,16 +108,6 @@ func HasResetTime() bool {
 	return cfg.Local.Options.NextReset.Unix() > 0
 }
 
-func disableNextReset() {
-	cfg.Local.Options.NextReset = time.Time{}
-	cfg.WriteLCfg()
-}
-
-func disableResetSchedule() {
-	cfg.Local.Options.ResetInterval = cfg.ResetInterval{}
-	cfg.WriteLCfg()
-}
-
 func TimeTillReset() string {
 	if !HasResetTime() {
 		return "No reset is scheduled"

--- a/main.go
+++ b/main.go
@@ -104,14 +104,16 @@ func main() {
 	<-sc
 
 	_ = os.Remove("cw.lock")
-	fact.SetAutolaunch(false, false)
-	glob.DoRebootCW = false
-	fact.QueueReboot = false
-	fact.QueueFactReboot = false
-	fact.QuitFactorio("Server quitting...")
-	fact.WaitFactQuit(false)
+	/*
+		fact.SetAutolaunch(false, false)
+		glob.DoRebootCW = false
+		fact.QueueReboot = false
+		fact.QueueFactReboot = false
+		fact.QuitFactorio("Server quitting...")
+		fact.WaitFactQuit(false)
 
-	fact.DoExit(false)
+		fact.DoExit(false)
+	*/
 }
 
 func startbotA() {

--- a/main.go
+++ b/main.go
@@ -113,9 +113,9 @@ func main() {
 		fact.QueueFactReboot = false
 		fact.QuitFactorio("Server quitting...")
 		fact.WaitFactQuit(false)
-
-		fact.DoExit(false)
 	*/
+
+	fact.DoExit(false)
 }
 
 func startbotA() {
@@ -229,7 +229,11 @@ func botReady(s *discordgo.Session, r *discordgo.Ready) {
 	if !support.BotIsReady {
 		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Status", constants.ProgName+" "+constants.Version+" is now online.", glob.COLOR_GREEN)
 		if fact.FactIsRunning || fact.FactorioBooted {
-			glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Ready", "Factorio "+fact.FactorioVersion+" is online.", glob.COLOR_GREEN)
+			var vers string
+			if fact.FactorioVersion != constants.Unknown {
+				vers = fact.FactorioVersion
+			}
+			glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Ready", "Factorio "+vers+" is online.", glob.COLOR_GREEN)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	_ "net/http/pprof"
@@ -80,6 +81,7 @@ func main() {
 	banlist.ReadBanFile(true)
 	fact.ReadVotes()
 	cwlog.StartGameLog()
+	support.AttachRunningFactorio(context.Background())
 	if *glob.PanelFlag {
 		panel.Start()
 	}

--- a/misc/factorio-agent.service
+++ b/misc/factorio-agent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=ChatWire Factorio Agent
+After=network.target
+
+[Service]
+Type=simple
+User=factorio
+ExecStart=/usr/local/bin/factorio-agent
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/support/factAgent.go
+++ b/support/factAgent.go
@@ -75,7 +75,7 @@ func (agentWriter) Close() error { return nil }
 // NewAgentWriter returns an io.WriteCloser that sends input to the Factorio agent.
 func NewAgentWriter() io.WriteCloser { return agentWriter{} }
 
-func AgentStart(args []string) error {
+func AgentStart(bin string, args []string) error {
 	socketLock.Lock()
 	defer socketLock.Unlock()
 	conn, err := getConn()
@@ -83,8 +83,9 @@ func AgentStart(args []string) error {
 		return err
 	}
 	buf := []byte{byte(agentCmdStart)}
-	if len(args) > 0 {
-		buf = append(buf, []byte(strings.Join(args, " ")+"\n")...)
+	all := append([]string{bin}, args...)
+	if len(all) > 0 {
+		buf = append(buf, []byte(strings.Join(all, " ")+"\n")...)
 	} else {
 		buf = append(buf, '\n')
 	}

--- a/support/factAgent.go
+++ b/support/factAgent.go
@@ -1,0 +1,105 @@
+package support
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"sync"
+)
+
+const agentSocket = "/var/run/factorio-agent.sock"
+
+var (
+	agentConn net.Conn
+	connLock  sync.Mutex
+	dialFn    = func() (net.Conn, error) { return net.Dial("unix", agentSocket) }
+)
+
+func getConn() (net.Conn, error) {
+	connLock.Lock()
+	defer connLock.Unlock()
+	if agentConn != nil {
+		return agentConn, nil
+	}
+	c, err := dialFn()
+	if err != nil {
+		return nil, err
+	}
+	agentConn = c
+	return agentConn, nil
+}
+
+func AgentStart(args []string) error {
+	conn, err := getConn()
+	if err != nil {
+		return err
+	}
+	buf := []byte{0x01}
+	if len(args) > 0 {
+		buf = append(buf, []byte(strings.Join(args, " ")+"\n")...)
+	} else {
+		buf = append(buf, '\n')
+	}
+	_, err = conn.Write(buf)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func AgentStop() error {
+	conn, err := getConn()
+	if err != nil {
+		return err
+	}
+	_, err = conn.Write([]byte{0x02})
+	return err
+}
+
+func AgentRunning() bool {
+	conn, err := getConn()
+	if err != nil {
+		return false
+	}
+	if _, err = conn.Write([]byte{0x03}); err != nil {
+		return false
+	}
+	resp := make([]byte, 1)
+	if _, err = conn.Read(resp); err != nil {
+		return false
+	}
+	return resp[0] == 1
+}
+
+func AgentWrite(line string) error {
+	conn, err := getConn()
+	if err != nil {
+		return err
+	}
+	_, err = conn.Write(append([]byte{0x04}, []byte(line+"\n")...))
+	return err
+}
+
+func AgentReadBuffered() ([]string, error) {
+	conn, err := getConn()
+	if err != nil {
+		return nil, err
+	}
+	if _, err = conn.Write([]byte{0x05}); err != nil {
+		return nil, err
+	}
+	r := bufio.NewReader(conn)
+	data, err := r.ReadBytes(0)
+	if err != nil {
+		return nil, err
+	}
+	data = data[:len(data)-1]
+	if len(data) == 0 {
+		return nil, nil
+	}
+	out := strings.Split(string(data), "\n")
+	if out[len(out)-1] == "" {
+		out = out[:len(out)-1]
+	}
+	return out, nil
+}

--- a/support/factAgent.go
+++ b/support/factAgent.go
@@ -4,11 +4,19 @@ import (
 	"bufio"
 	"io"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 )
 
-const agentSocket = "/var/run/factorio-agent.sock"
+var agentSocket = func() string {
+	ex, err := os.Executable()
+	if err != nil {
+		return filepath.Join("agent", "factorio-agent.sock")
+	}
+	return filepath.Join(filepath.Dir(ex), "agent", "factorio-agent.sock")
+}()
 
 type agentCmd byte
 

--- a/support/factAgent.go
+++ b/support/factAgent.go
@@ -20,9 +20,9 @@ import (
 var agentSocket = func() string {
 	ex, err := os.Executable()
 	if err != nil {
-		return filepath.Join("agent", "factorio-agent.sock")
+		return "factorio-agent.sock"
 	}
-	return filepath.Join(filepath.Dir(ex), "agent", "factorio-agent.sock")
+	return filepath.Join(filepath.Dir(ex), "factorio-agent.sock")
 }()
 
 type agentCmd byte

--- a/support/factAgent_test.go
+++ b/support/factAgent_test.go
@@ -16,12 +16,12 @@ func TestAgentStartSend(t *testing.T) {
 		n, _ := c2.Read(buf)
 		done <- buf[:n]
 	}()
-	if err := AgentStart([]string{"a", "b"}); err != nil {
+	if err := AgentStart("bin", []string{"a", "b"}); err != nil {
 		t.Fatalf("AgentStart error: %v", err)
 	}
 	out := <-done
 	exp := []byte{byte(agentCmdStart)}
-	exp = append(exp, []byte("a b\n")...)
+	exp = append(exp, []byte("bin a b\n")...)
 	if !bytes.Equal(out, exp) {
 		t.Fatalf("unexpected bytes %v", out)
 	}

--- a/support/factAgent_test.go
+++ b/support/factAgent_test.go
@@ -1,0 +1,108 @@
+package support
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func TestAgentStartSend(t *testing.T) {
+	c1, c2 := net.Pipe()
+	dialFn = func() (net.Conn, error) { return c1, nil }
+	agentConn = nil
+	done := make(chan []byte)
+	go func() {
+		buf := make([]byte, 32)
+		n, _ := c2.Read(buf)
+		done <- buf[:n]
+	}()
+	if err := AgentStart([]string{"a", "b"}); err != nil {
+		t.Fatalf("AgentStart error: %v", err)
+	}
+	out := <-done
+	exp := []byte{0x01}
+	exp = append(exp, []byte("a b\n")...)
+	if !bytes.Equal(out, exp) {
+		t.Fatalf("unexpected bytes %v", out)
+	}
+	c1.Close()
+	c2.Close()
+}
+
+func TestAgentStopSend(t *testing.T) {
+	c1, c2 := net.Pipe()
+	dialFn = func() (net.Conn, error) { return c1, nil }
+	agentConn = nil
+	done := make(chan []byte)
+	go func() {
+		buf := make([]byte, 2)
+		n, _ := c2.Read(buf)
+		done <- buf[:n]
+	}()
+	if err := AgentStop(); err != nil {
+		t.Fatalf("AgentStop error: %v", err)
+	}
+	out := <-done
+	if !bytes.Equal(out, []byte{0x02}) {
+		t.Fatalf("unexpected bytes %v", out)
+	}
+	c1.Close()
+	c2.Close()
+}
+
+func TestAgentRunning(t *testing.T) {
+	c1, c2 := net.Pipe()
+	dialFn = func() (net.Conn, error) { return c1, nil }
+	agentConn = nil
+	go func() {
+		buf := make([]byte, 1)
+		c2.Read(buf)
+		c2.Write([]byte{1})
+	}()
+	if !AgentRunning() {
+		t.Fatalf("expected running true")
+	}
+	c1.Close()
+	c2.Close()
+}
+
+func TestAgentWrite(t *testing.T) {
+	c1, c2 := net.Pipe()
+	dialFn = func() (net.Conn, error) { return c1, nil }
+	agentConn = nil
+	done := make(chan []byte)
+	go func() {
+		buf := make([]byte, 16)
+		n, _ := c2.Read(buf)
+		done <- buf[:n]
+	}()
+	if err := AgentWrite("cmd"); err != nil {
+		t.Fatalf("AgentWrite error: %v", err)
+	}
+	out := <-done
+	if !bytes.Equal(out, []byte{0x04, 'c', 'm', 'd', '\n'}) {
+		t.Fatalf("unexpected bytes %v", out)
+	}
+	c1.Close()
+	c2.Close()
+}
+
+func TestAgentReadBuffered(t *testing.T) {
+	c1, c2 := net.Pipe()
+	dialFn = func() (net.Conn, error) { return c1, nil }
+	agentConn = nil
+	go func() {
+		buf := make([]byte, 1)
+		c2.Read(buf) // read request
+		c2.Write([]byte("line1\nline2\n\x00"))
+	}()
+	lines, err := AgentReadBuffered()
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if len(lines) != 2 || lines[0] != "line1" || lines[1] != "line2" {
+		t.Fatalf("unexpected lines %v", lines)
+	}
+	c1.Close()
+	c2.Close()
+}

--- a/support/factAgent_test.go
+++ b/support/factAgent_test.go
@@ -20,7 +20,7 @@ func TestAgentStartSend(t *testing.T) {
 		t.Fatalf("AgentStart error: %v", err)
 	}
 	out := <-done
-	exp := []byte{0x01}
+	exp := []byte{byte(agentCmdStart)}
 	exp = append(exp, []byte("a b\n")...)
 	if !bytes.Equal(out, exp) {
 		t.Fatalf("unexpected bytes %v", out)
@@ -43,7 +43,7 @@ func TestAgentStopSend(t *testing.T) {
 		t.Fatalf("AgentStop error: %v", err)
 	}
 	out := <-done
-	if !bytes.Equal(out, []byte{0x02}) {
+	if !bytes.Equal(out, []byte{byte(agentCmdStop)}) {
 		t.Fatalf("unexpected bytes %v", out)
 	}
 	c1.Close()
@@ -80,7 +80,7 @@ func TestAgentWrite(t *testing.T) {
 		t.Fatalf("AgentWrite error: %v", err)
 	}
 	out := <-done
-	if !bytes.Equal(out, []byte{0x04, 'c', 'm', 'd', '\n'}) {
+	if !bytes.Equal(out, []byte{byte(agentCmdWrite), 'c', 'm', 'd', '\n'}) {
 		t.Fatalf("unexpected bytes %v", out)
 	}
 	c1.Close()

--- a/support/launcher.go
+++ b/support/launcher.go
@@ -547,17 +547,6 @@ func launchFactorio() {
 		}
 	}
 
-	/* Hide RCON password and port */
-	/*
-		for i, targ := range tempargs {
-			if targ == rconpass {
-				tempargs[i] = "***private***"
-			} else if targ == rconportStr {
-				tempargs[i] = "69420"
-			}
-		}
-	*/
-
 	/* Okay, prep for factorio launch */
 	fact.SetFactRunning(true, false)
 	fact.FactorioBooted = false
@@ -572,8 +561,20 @@ func launchFactorio() {
 	glob.NoResponseCount = 0
 	cwlog.DoLogCW("Factorio booting...")
 
+	/* Hide RCON password and port */
+	var logArgs []string
+	for _, targ := range tempargs {
+		if targ == rconpass {
+			logArgs = append(logArgs, "***private***")
+		} else if targ == rconportStr {
+			logArgs = append(logArgs, "69420")
+		} else {
+			logArgs = append(logArgs, targ)
+		}
+	}
+
 	/* Launch Factorio via agent */
-	cwlog.DoLogCW("Executing: " + fact.GetFactorioBinary() + " " + strings.Join(tempargs, " "))
+	cwlog.DoLogCW("Executing: " + fact.GetFactorioBinary() + " " + strings.Join(logArgs, " "))
 	fact.GameBuffer = new(bytes.Buffer)
 	fact.PipeLock.Lock()
 	fact.Pipe = NewAgentWriter()

--- a/support/launcher.go
+++ b/support/launcher.go
@@ -13,7 +13,6 @@ import (
 	"path"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 
 	"ChatWire/cfg"
@@ -367,22 +366,6 @@ func waitForDiscord() {
 		cwlog.DoLogCW("Waiting for Discord...")
 		time.Sleep(time.Second)
 	}
-}
-
-func isProcessRunning(cmd *exec.Cmd) bool {
-	// Check if the process state is nil (still running)
-	if cmd.ProcessState == nil {
-		return true
-	}
-
-	// Check if the process has exited
-	return !cmd.ProcessState.Exited()
-}
-
-func isProcessAlive(pid int) bool {
-	// Send signal 0 to the process
-	err := syscall.Kill(pid, 0)
-	return err == nil
 }
 
 /* Create config files, launch factorio */

--- a/support/launcher.go
+++ b/support/launcher.go
@@ -590,7 +590,7 @@ func launchFactorio() {
 			time.Sleep(time.Millisecond * 100)
 		}
 	}()
-	err = AgentStart(tempargs)
+	err = AgentStart(fact.GetFactorioBinary(), tempargs)
 	if err != nil {
 		fact.LogCMS(cfg.Local.Channel.ChatChannel, fmt.Sprintf("An error occurred when attempting to start the game via agent. Details: %s", err))
 		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "ERROR", "Launching Factorio failed!", glob.COLOR_RED)

--- a/support/launcher.go
+++ b/support/launcher.go
@@ -548,14 +548,15 @@ func launchFactorio() {
 	}
 
 	/* Hide RCON password and port */
-	for i, targ := range tempargs {
-		if targ == rconpass {
-			tempargs[i] = "***private***"
-		} else if targ == rconportStr {
-			/* funny, and impossible port number  */
-			tempargs[i] = "69420"
+	/*
+		for i, targ := range tempargs {
+			if targ == rconpass {
+				tempargs[i] = "***private***"
+			} else if targ == rconportStr {
+				tempargs[i] = "69420"
+			}
 		}
-	}
+	*/
 
 	/* Okay, prep for factorio launch */
 	fact.SetFactRunning(true, false)

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -101,7 +101,7 @@ func MainLoops() {
 				/* Just in case factorio hangs, bogs down or is flooded */
 				if nores == 120 {
 					msg := "Factorio unresponsive for over two minutes... rebooting."
-					fact.LogGameCMS(true, cfg.Local.Channel.ChatChannel, msg)
+					//fact.LogGameCMS(true, cfg.Local.Channel.ChatChannel, msg)
 					glob.RelaunchThrottle = 0
 					fact.QuitFactorio(msg)
 				}
@@ -496,7 +496,7 @@ func MainLoops() {
 
 				if fact.QueueReboot && !fact.DoUpdateFactorio {
 					cwlog.DoLogCW("No players currently online, performing scheduled reboot.")
-					fact.QuitFactorio("Server rebooting for maintenance.")
+					//fact.QuitFactorio("Server rebooting for maintenance.")
 					break //We don't need to loop anymore, rebooting chat wire.
 
 				} else if fact.QueueFactReboot && !fact.DoUpdateFactorio {

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"os"
-	"os/exec"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -22,10 +20,6 @@ import (
 	"ChatWire/modupdate"
 	"ChatWire/util"
 )
-
-func linuxSetProcessGroup(cmd *exec.Cmd) {
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-}
 
 /********************
  * Main threads/loops


### PR DESCRIPTION
## Summary
- implement factorio-agent service using Unix socket
- add client wrapper and tests
- launch Factorio via AgentStart
- provide example systemd unit
- document agent protocol

## Testing
- `go vet ./...`
- `go test ./support -run TestAgent -v`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684c94048b78832a9ae8155f8fa77025