### PR TITLE
Add debug flag to agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Ensure the generated configuration files contain your Discord token, application
 ChatWire can run Factorio through a small helper daemon. The agent listens on a
 Unix socket located next to the agent binary (e.g. `factorio-agent.sock`) and understands a byte protocol:
 
+The `-debug` flag prints verbose logs from the agent. Without it the agent runs silently.
+
 ```
 0x01 <binary> <args>\n  start Factorio (binary path followed by arguments)
 0x02          stop Factorio

--- a/agent/main.go
+++ b/agent/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"errors"
+	"flag"
 	"io"
 	"log"
 	"net"
@@ -38,9 +39,14 @@ var (
 	outBuf   []string
 	connLock sync.Mutex
 	conns    = make(map[net.Conn]struct{})
+	debug    = flag.Bool("debug", false, "enable debug logging")
 )
 
 func main() {
+	flag.Parse()
+	if !*debug {
+		log.SetOutput(io.Discard)
+	}
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	ex, err := os.Executable()
 	if err != nil {


### PR DESCRIPTION
## Summary
- support optional verbose logging in the Factorio agent
- document new `-debug` flag in README

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684cc6f42244832abe7ece0f7f820a04