### PR TITLE
Add tests for map reset timing

### DIFF
--- a/commands/moderator/hourLimits_test.go
+++ b/commands/moderator/hourLimits_test.go
@@ -1,0 +1,42 @@
+package moderator
+
+import (
+	"ChatWire/cfg"
+	"github.com/bwmarrin/discordgo"
+	"os"
+	"testing"
+)
+
+func TestConfigHours(t *testing.T) {
+	oldwd, _ := os.Getwd()
+	dir := t.TempDir()
+	os.Chdir(dir)
+	defer os.Chdir(oldwd)
+
+	origEnable := cfg.Local.Options.PlayHourEnable
+	origStart := cfg.Local.Options.PlayStartHour
+	origEnd := cfg.Local.Options.PlayEndHour
+	defer func() {
+		cfg.Local.Options.PlayHourEnable = origEnable
+		cfg.Local.Options.PlayStartHour = origStart
+		cfg.Local.Options.PlayEndHour = origEnd
+	}()
+
+	ic := &discordgo.InteractionCreate{Interaction: &discordgo.Interaction{
+		Type:   discordgo.InteractionApplicationCommand,
+		Member: &discordgo.Member{User: &discordgo.User{Username: "tester"}},
+		Data: discordgo.ApplicationCommandInteractionData{
+			Options: []*discordgo.ApplicationCommandInteractionDataOption{
+				{Name: "enabled", Type: discordgo.ApplicationCommandOptionBoolean, Value: true},
+				{Name: "start-hour", Type: discordgo.ApplicationCommandOptionInteger, Value: float64(3)},
+				{Name: "end-hour", Type: discordgo.ApplicationCommandOptionInteger, Value: float64(5)},
+			},
+		},
+	}}
+
+	ConfigHours(nil, ic)
+
+	if !cfg.Local.Options.PlayHourEnable || cfg.Local.Options.PlayStartHour != 3 || cfg.Local.Options.PlayEndHour != 5 {
+		t.Fatalf("options not set correctly")
+	}
+}

--- a/commands/moderator/setSchedule_test.go
+++ b/commands/moderator/setSchedule_test.go
@@ -1,0 +1,33 @@
+package moderator
+
+import (
+	"ChatWire/cfg"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseResetDate(t *testing.T) {
+	orig := cfg.Local.Options.NextReset
+	defer func() { cfg.Local.Options.NextReset = orig }()
+
+	future := time.Now().UTC().Add(time.Hour)
+	out := parseResetDate(future.Format("2006-01-02 15-04-05"))
+	if !strings.HasPrefix(out, "Date accepted:") {
+		t.Fatalf("unexpected output %q", out)
+	}
+	if !cfg.Local.Options.NextReset.Equal(future.Round(time.Second)) && cfg.Local.Options.NextReset.Sub(future) > time.Second {
+		t.Fatalf("reset time not set")
+	}
+
+	past := time.Now().UTC().Add(-time.Hour)
+	out = parseResetDate(past.Format("2006-01-02 15-04-05"))
+	if out != "That date is in the past, rejecting." {
+		t.Fatalf("unexpected output %q", out)
+	}
+
+	out = parseResetDate("bad format")
+	if out != "Unable to parse date provided. Format is 'YYYY-MM-DD HH-MM-SS' (24-hour UTC)" {
+		t.Fatalf("unexpected output %q", out)
+	}
+}

--- a/fact/newCron_test.go
+++ b/fact/newCron_test.go
@@ -1,0 +1,80 @@
+package fact
+
+import (
+	"ChatWire/cfg"
+	"testing"
+	"time"
+)
+
+func TestFormatResetTime(t *testing.T) {
+	orig := cfg.Local.Options.NextReset
+	defer func() { cfg.Local.Options.NextReset = orig }()
+
+	cfg.Local.Options.NextReset = time.Time{}
+	if got := FormatResetTime(); got != "No reset is scheduled" {
+		t.Fatalf("unexpected %q", got)
+	}
+
+	tval := time.Date(2025, time.January, 2, 15, 4, 0, 0, time.UTC)
+	cfg.Local.Options.NextReset = tval
+	exp := tval.UTC().Format("Jan 02, 03:04PM UTC")
+	if got := FormatResetTime(); got != exp {
+		t.Fatalf("expected %q got %q", exp, got)
+	}
+}
+
+func TestFormatResetInterval(t *testing.T) {
+	orig := cfg.Local.Options.ResetInterval
+	defer func() { cfg.Local.Options.ResetInterval = orig }()
+
+	cfg.Local.Options.ResetInterval = cfg.ResetInterval{}
+	if got := FormatResetInterval(); got != "No reset interval is set" {
+		t.Fatalf("unexpected %q", got)
+	}
+
+	cfg.Local.Options.ResetInterval = cfg.ResetInterval{Months: 1, Days: 2, Hours: 3}
+	if got := FormatResetInterval(); got != "Every 1 month, 2 days, 3 hours" {
+		t.Fatalf("unexpected %q", got)
+	}
+}
+
+func TestSetResetDateAdvanceAndTimeTill(t *testing.T) {
+	origNext := cfg.Local.Options.NextReset
+	origInterval := cfg.Local.Options.ResetInterval
+	origHour := cfg.Local.Options.ResetHour
+	defer func() {
+		cfg.Local.Options.NextReset = origNext
+		cfg.Local.Options.ResetInterval = origInterval
+		cfg.Local.Options.ResetHour = origHour
+	}()
+
+	cfg.Local.Options.ResetInterval = cfg.ResetInterval{Hours: 2}
+	cfg.Local.Options.ResetHour = 0
+	start := time.Now().UTC()
+	SetResetDate()
+	diff := cfg.Local.Options.NextReset.Sub(start.Add(2 * time.Hour))
+	if diff < -time.Second || diff > time.Second {
+		t.Fatalf("unexpected next reset diff %v", diff)
+	}
+
+	start = cfg.Local.Options.NextReset
+	AdvanceReset()
+	if !cfg.Local.Options.NextReset.Equal(start.Add(2 * time.Hour)) {
+		t.Fatalf("advance failed: %v", cfg.Local.Options.NextReset.Sub(start))
+	}
+
+	cfg.Local.Options.NextReset = time.Now().UTC().Add(90 * time.Minute).Round(time.Second)
+	if got := TimeTillReset(); got != "1 hour 30 minutes" {
+		t.Fatalf("unexpected till reset %q", got)
+	}
+
+	cfg.Local.Options.NextReset = time.Now().UTC().Add(70 * time.Second).Round(time.Second)
+	if got := TimeTillReset(); got != "1 minute" {
+		t.Fatalf("unexpected till reset %q", got)
+	}
+
+	cfg.Local.Options.NextReset = time.Time{}
+	if got := TimeTillReset(); got != "No reset is scheduled" {
+		t.Fatalf("unexpected %q", got)
+	}
+}

--- a/support/hours_test.go
+++ b/support/hours_test.go
@@ -1,0 +1,41 @@
+package support
+
+import (
+	"ChatWire/cfg"
+	"testing"
+	"time"
+)
+
+func TestWithinHours(t *testing.T) {
+	cur := time.Now().UTC().Hour()
+
+	cfg.Local.Options.PlayHourEnable = false
+	if !WithinHours() {
+		t.Fatalf("expected true when disabled")
+	}
+
+	cfg.Local.Options.PlayHourEnable = true
+	cfg.Local.Options.PlayStartHour = (cur + 23) % 24
+	cfg.Local.Options.PlayEndHour = (cur + 1) % 24
+	if !WithinHours() {
+		t.Fatalf("expected true within window")
+	}
+
+	cfg.Local.Options.PlayStartHour = (cur + 1) % 24
+	cfg.Local.Options.PlayEndHour = (cur + 2) % 24
+	if WithinHours() {
+		t.Fatalf("expected false outside window")
+	}
+
+	cfg.Local.Options.PlayStartHour = (cur + 2) % 24
+	cfg.Local.Options.PlayEndHour = (cur + 1) % 24
+	if !WithinHours() {
+		t.Fatalf("expected true across midnight")
+	}
+
+	cfg.Local.Options.PlayStartHour = (cur + 1) % 24
+	cfg.Local.Options.PlayEndHour = (cur + 23) % 24
+	if WithinHours() {
+		t.Fatalf("expected false outside wrapped window")
+	}
+}


### PR DESCRIPTION
## Summary
- extend fact/newCron_test.go with coverage for SetResetDate, AdvanceReset and TimeTillReset

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684cde2cf92c832a8db211afbf1eacc6