### PR TITLE
Improve Factorio watchdog robustness

### DIFF
--- a/fact/util.go
+++ b/fact/util.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -192,11 +193,11 @@ func SetFactRunning(run, report bool) {
 	wasrun := FactIsRunning
 	FactIsRunning = run
 
-	if run && glob.NoResponseCount >= 15 && !FactorioBootedAt.IsZero() && time.Since(FactorioBootedAt) > time.Minute {
+	if run && atomic.LoadInt32(&glob.NoResponseCount) >= 15 && !FactorioBootedAt.IsZero() && time.Since(FactorioBootedAt) > time.Minute {
 		//CMS(cfg.Local.Channel.ChatChannel, "Server now appears to be responding again.")
 		cwlog.DoLogCW("Server now appears to be responding again.")
 	}
-	glob.NoResponseCount = 0
+	atomic.StoreInt32(&glob.NoResponseCount, 0)
 
 	if wasrun != run {
 		if !run {
@@ -370,7 +371,7 @@ func QuitFactorio(message string) {
 	}
 
 	glob.RelaunchThrottle = 0
-	glob.NoResponseCount = 0
+	atomic.StoreInt32(&glob.NoResponseCount, 0)
 
 	/* Running but no players, just quit */
 	if (FactorioBooted && FactIsRunning) && NumPlayers <= 0 {

--- a/glob/var.go
+++ b/glob/var.go
@@ -92,7 +92,7 @@ var (
 	LocalCfgUpdatedLock sync.Mutex
 
 	/* Factorio server watchdog */
-	NoResponseCount = 0
+	NoResponseCount int32
 
 	/* Update warning */
 	UpdateWarnCounter  = 0

--- a/support/launcher.go
+++ b/support/launcher.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"time"
 
+	"sync/atomic"
+
 	"ChatWire/cfg"
 	"ChatWire/constants"
 	"ChatWire/cwlog"
@@ -541,7 +543,7 @@ func launchFactorio() {
 	fact.FactorioBootedAt = time.Now()
 
 	fact.Gametime = (constants.Unknown)
-	glob.NoResponseCount = 0
+	atomic.StoreInt32(&glob.NoResponseCount, 0)
 	cwlog.DoLogCW("Factorio booting...")
 
 	/* Hide RCON password and port */

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	"sync/atomic"
 
 	"ChatWire/banlist"
 	"ChatWire/cfg"
@@ -84,11 +85,9 @@ func MainLoops() {
 			} else if fact.FactIsRunning && fact.FactorioBooted {
 
 				/* If the game isn't paused, check game time */
-				nores := 0
+				var nores int32
 				if fact.PausedTicks <= constants.PauseThresh {
-
-					glob.NoResponseCount = glob.NoResponseCount + 1
-					nores = glob.NoResponseCount
+					nores = atomic.AddInt32(&glob.NoResponseCount, 1)
 
 					fact.WriteFact("/time")
 				}

--- a/support/pipeHandle.go
+++ b/support/pipeHandle.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"sync/atomic"
+
 	embed "github.com/Clinet/discordgo-embed"
 	"github.com/dustin/go-humanize"
 
@@ -1085,7 +1087,7 @@ func handleChatMsg(input *handleData) bool {
 
 			if pname != "<server>" {
 
-				var nores int = glob.NoResponseCount
+				nores := atomic.LoadInt32(&glob.NoResponseCount)
 
 				if !cfg.Global.Options.DisableSpamProtect {
 					glob.ChatterLock.Lock()

--- a/support/pipeParse.go
+++ b/support/pipeParse.go
@@ -9,6 +9,7 @@ import (
 	"ChatWire/fact"
 	"ChatWire/glob"
 	"ChatWire/sclean"
+	"sync/atomic"
 )
 
 type funcList struct {
@@ -68,7 +69,7 @@ func HandleChat() {
 
 				/* We have input, server is alive */
 				//fact.SetFactRunning(true, false)
-				glob.NoResponseCount = 0
+				atomic.StoreInt32(&glob.NoResponseCount, 0)
 
 				/* Decrement every time we see activity, if we see time not progressing, add two */
 				if fact.PausedTicks > 0 {


### PR DESCRIPTION
## Summary
- make `glob.NoResponseCount` an atomic counter
- reset the counter using `atomic.StoreInt32`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d0ede0bc4832ab6220cc6db01783f