### PR TITLE
Add rcon persistence and run startup commands on attach

### DIFF
--- a/cfg/struct.go
+++ b/cfg/struct.go
@@ -115,9 +115,9 @@ type globalOptions struct {
 type local struct {
 	Callsign       string `form:"RO"`
 	Name           string
-	Port           int    `form:"RO"`
-	RCONPass       string `json:"-"`
-	LastSaveBackup int    `form:"RO" web:"Last Backup Slot"`
+	Port           int `form:"RO"`
+	RCONPass       string
+	LastSaveBackup int `form:"RO" web:"Last Backup Slot"`
 
 	Settings settings
 

--- a/main.go
+++ b/main.go
@@ -326,6 +326,7 @@ func readConfigs() {
 	}
 	if cfg.ReadLCfg() {
 		util.SetTempFilePrefix(cfg.Local.Callsign + "-")
+		glob.RCONPass = cfg.Local.RCONPass
 		//cfg.WriteLCfg()
 	} else {
 		time.Sleep(constants.ErrorDelayShutdown * time.Second)

--- a/support/factAgent.go
+++ b/support/factAgent.go
@@ -282,5 +282,7 @@ func AttachRunningFactorio(ctx context.Context) bool {
 	fact.FactorioBooted = true
 	fact.FactorioBootedAt = time.Now()
 	fact.SetFactRunning(true, false)
+	fact.WriteFact("/sversion")
+	fact.WriteFact(glob.OnlineCommand)
 	return true
 }


### PR DESCRIPTION
## Summary
- persist the RCON password in local configuration
- run `/sversion` and the online command when attaching to a running Factorio instance
- load saved RCON password into globals on startup

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d162bc388832a886762fe1185c9d6