### PR TITLE
Add optional Discord and updater tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ Binary:<br>
 | `-regCommands` | Register Discord commands. |
 <br>
 
-### Discord bot perms:
-The bot needs presence intent, server members intent, message content intent
-Perms: view channels, manage channels, Manage roles, send messages, embed links, attach files, mention all roles, manage messages (delete message, if register code leaked), read message history, use application commands.
+### Setting up your Discord bot
+1. Visit <https://discord.com/developers/applications> and create a **New Application**.
+2. Under **Bot** click **Add Bot**. Enable the *Presence*, *Server Members* and *Message Content* intents and grant these permissions: view channels, manage channels, manage roles, send messages, embed links, attach files, mention all roles, manage messages (delete message if register code leaked), read message history and use application commands.
+3. Copy the **Token** from the bot page and note the **Application ID** from *OAuth2 > General*.
+4. In Discord enable *Developer Mode* and right click your server to **Copy ID** for the guild ID.
+5. Copy a channel ID or leave `ChatChannel` blank in `cw-local-config.json` and ChatWire will create one on first run.
 
 ### Development and Testing
 
@@ -81,6 +84,7 @@ go vet ./...
 go test ./...
 ```
 These are the same checks executed by the CI pipeline.
+Some integration tests connect to Discord. Set CW_TEST_TOKEN, CW_TEST_GUILD and CW_TEST_APP to enable them.
 
 ### Regenerating configuration
 

--- a/disc/channel_test.go
+++ b/disc/channel_test.go
@@ -1,0 +1,37 @@
+package disc
+
+import (
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// TestCreateChannel connects to Discord using credentials from environment
+// variables and creates then deletes a temporary channel. It is skipped when
+// CW_TEST_TOKEN or CW_TEST_GUILD is not set.
+func TestCreateChannel(t *testing.T) {
+	token := os.Getenv("CW_TEST_TOKEN")
+	guild := os.Getenv("CW_TEST_GUILD")
+	if token == "" || guild == "" {
+		t.Skip("CW_TEST_TOKEN or CW_TEST_GUILD not set")
+	}
+
+	s, err := discordgo.New("Bot " + token)
+	if err != nil {
+		t.Fatalf("session create: %v", err)
+	}
+	defer s.Close()
+
+	name := "cw-test-" + strconv.FormatInt(time.Now().Unix(), 10)
+	ch, err := s.GuildChannelCreate(guild, name, discordgo.ChannelTypeGuildText)
+	if err != nil {
+		t.Fatalf("create channel: %v", err)
+	}
+
+	if _, err := s.ChannelDelete(ch.ID); err != nil {
+		t.Fatalf("delete channel: %v", err)
+	}
+}

--- a/disc/command_test.go
+++ b/disc/command_test.go
@@ -1,0 +1,37 @@
+package disc
+
+import (
+	"os"
+	"testing"
+
+	"github.com/bwmarrin/discordgo"
+)
+
+// TestCreateCommand registers a simple command and deletes it again when
+// CW_TEST_TOKEN, CW_TEST_GUILD and CW_TEST_APP are set.
+func TestCreateCommand(t *testing.T) {
+	token := os.Getenv("CW_TEST_TOKEN")
+	guild := os.Getenv("CW_TEST_GUILD")
+	app := os.Getenv("CW_TEST_APP")
+	if token == "" || guild == "" || app == "" {
+		t.Skip("CW_TEST_TOKEN/GUILD/APP not set")
+	}
+
+	s, err := discordgo.New("Bot " + token)
+	if err != nil {
+		t.Fatalf("session create: %v", err)
+	}
+	defer s.Close()
+
+	cmd, err := s.ApplicationCommandCreate(app, guild, &discordgo.ApplicationCommand{
+		Name:        "cwtest",
+		Description: "temporary test command",
+	})
+	if err != nil {
+		t.Fatalf("create command: %v", err)
+	}
+
+	if err := s.ApplicationCommandDelete(app, guild, cmd.ID); err != nil {
+		t.Fatalf("delete command: %v", err)
+	}
+}

--- a/factUpdater/util_test.go
+++ b/factUpdater/util_test.go
@@ -1,0 +1,71 @@
+package factUpdater
+
+import (
+	"archive/tar"
+	"bytes"
+	"testing"
+)
+
+// helper to build a simple tar archive from a list of file names
+func buildTar(files []string) []byte {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for _, name := range files {
+		hdr := &tar.Header{Name: name, Mode: 0600, Size: int64(len(name))}
+		tw.WriteHeader(hdr)
+		tw.Write([]byte(name))
+	}
+	tw.Close()
+	return buf.Bytes()
+}
+
+func TestCheckInstallTar(t *testing.T) {
+	files := []string{
+		"factorio/data/eula.txt",
+		"factorio/data/licenses.txt",
+		"factorio/data/credits.txt",
+		"factorio/data/changelog.txt",
+		"factorio/data/core/backers.json",
+		"factorio/data/core/data.lua",
+		"factorio/data/core/info.json",
+	}
+	if err := checkInstallTar(buildTar(files)); err != nil {
+		t.Fatalf("valid archive: %v", err)
+	}
+	bad := files[:len(files)-1]
+	if err := checkInstallTar(buildTar(bad)); err == nil {
+		t.Fatalf("expected error when file missing")
+	}
+}
+
+func TestParseVersionString(t *testing.T) {
+	v, err := parseVersionString("1.2.3")
+	if err != nil || v.A != 1 || v.B != 2 || v.C != 3 {
+		t.Fatalf("unexpected: %v %v", v, err)
+	}
+	if _, err := parseVersionString("1.2"); err == nil {
+		t.Fatalf("expected error on short version")
+	}
+}
+
+func TestVersionCompare(t *testing.T) {
+	a := versionInts{A: 1, B: 2, C: 3}
+	b := versionInts{A: 1, B: 2, C: 2}
+	if !isVersionNewerThan(a, b) {
+		t.Fatalf("expected newer")
+	}
+	if isVersionNewerThan(b, a) {
+		t.Fatalf("expected older")
+	}
+	if !isVersionEqual(a, versionInts{1, 2, 3}) {
+		t.Fatalf("equality failed")
+	}
+}
+
+func TestParseFactorioVersion(t *testing.T) {
+	input := "Version: 1.1.90 (build 12345, linux64, headless)"
+	v, bld, dist, err := parseFactorioVersion(input)
+	if err != nil || v.A != 1 || v.C != 90 || bld != "headless" || dist != "linux64" {
+		t.Fatalf("unexpected output: %v %v %v %v", v, bld, dist, err)
+	}
+}


### PR DESCRIPTION
## Summary
- create integration test for Discord command registration
- add factorio updater utility tests
- note required environment variables for integration tests

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684de04b39cc832a8d644ac956bf8bd1