### PR TITLE
Fix Factorio agent reading to handle long output lines

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -181,12 +181,17 @@ func startFactorio(args []string) error {
 
 func readStdout(r io.Reader) {
 	scanner := bufio.NewScanner(r)
+	// allow up to 1MB long lines from Factorio
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Text()
 		log.Printf("stdout: %s", line)
 		bufLock.Lock()
 		outBuf = append(outBuf, line)
 		bufLock.Unlock()
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("stdout scan error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- prevent Factorio agent stdout reader from stopping on long lines

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f13f86a50832aa90837a88e5a971c