### PR TITLE
Fix agent reading to handle huge stdout lines

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -180,13 +180,22 @@ func startFactorio(args []string) error {
 }
 
 func readStdout(r io.Reader) {
-	scanner := bufio.NewScanner(r)
-	for scanner.Scan() {
-		line := scanner.Text()
-		log.Printf("stdout: %s", line)
-		bufLock.Lock()
-		outBuf = append(outBuf, line)
-		bufLock.Unlock()
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadString('\n')
+		if len(line) > 0 {
+			line = strings.TrimRight(line, "\n")
+			log.Printf("stdout: %s", line)
+			bufLock.Lock()
+			outBuf = append(outBuf, line)
+			bufLock.Unlock()
+		}
+		if err != nil {
+			if !errors.Is(err, io.EOF) {
+				log.Printf("stdout read error: %v", err)
+			}
+			return
+		}
 	}
 }
 

--- a/agent/main_test.go
+++ b/agent/main_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"bytes"
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -47,4 +49,19 @@ func TestHandleConnUnknown(t *testing.T) {
 	c2.Write([]byte{0xff})
 	c2.Close()
 	<-done
+}
+
+func TestReadStdoutLongLine(t *testing.T) {
+	longLine := strings.Repeat("a", 2*1024*1024) + "\nshort\n"
+	outBuf = nil
+	readStdout(bytes.NewBufferString(longLine))
+	if len(outBuf) != 2 {
+		t.Fatalf("expected 2 lines, got %d", len(outBuf))
+	}
+	if outBuf[0] != strings.Repeat("a", 2*1024*1024) {
+		t.Fatalf("long line mismatch")
+	}
+	if outBuf[1] != "short" {
+		t.Fatalf("short line mismatch: %q", outBuf[1])
+	}
 }


### PR DESCRIPTION
## Summary
- replace bufio.Scanner with bufio.Reader in agent stdout reader
- add unit test for very long Factorio log lines

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f13f86a50832aa90837a88e5a971c