### PR TITLE
Fix scanner variable reference

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -197,9 +197,6 @@ func readStdout(r io.Reader) {
 			return
 		}
 	}
-	if err := scanner.Err(); err != nil {
-		log.Printf("stdout scan error: %v", err)
-	}
 }
 
 func stopFactorio() {


### PR DESCRIPTION
## Summary
- remove dangling `scanner.Err()` check in `readStdout`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f1ddd934c832abf085d0e0b9e0bb7