### PR TITLE
Fix redeclared functions in factAgent.go

### DIFF
--- a/support/factAgent.go
+++ b/support/factAgent.go
@@ -66,34 +66,6 @@ func agentReconnected() {
 		disc.SmartWriteDiscord(cfg.Global.Discord.ReportChannel, "Reconnected to Factorio agent.")
 	}
 
-	if fact.FactIsRunning || fact.FactorioBooted {
-		return
-	}
-
-	if AttachRunningFactorio(context.Background()) {
-		return
-	}
-
-	if fact.FactAutoStart && !*glob.NoAutoLaunch {
-		launchFactorio()
-	}
-}
-
-func agentLost() {
-	if !alertAgent {
-		alertAgent = true
-		cwlog.DoLogCW("Agent connection lost, attempting to reconnect")
-		disc.SmartWriteDiscord(cfg.Global.Discord.ReportChannel, "Lost connection to Factorio agent, attempting to reconnect.")
-	}
-}
-
-func agentReconnected() {
-	if alertAgent {
-		alertAgent = false
-		cwlog.DoLogCW("Agent connection established")
-		disc.SmartWriteDiscord(cfg.Global.Discord.ReportChannel, "Reconnected to Factorio agent.")
-	}
-
 	if fact.FactIsRunning {
 		return
 	}


### PR DESCRIPTION
## Summary
- remove duplicate `agentLost` and `agentReconnected` declarations

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684f37fdd378832a9b97db32b4f5d153