### PR TITLE
Protect BootMessage access with mutex helpers

### DIFF
--- a/commands/moderator/upload.go
+++ b/commands/moderator/upload.go
@@ -83,7 +83,7 @@ func UploadFile(cmd *glob.CommandData, i *discordgo.InteractionCreate) {
 		}
 
 		if doLaunch {
-			glob.BootMessage = nil
+			glob.SetBootMessage(nil)
 			glob.RelaunchThrottle = 0
 			fact.SetAutolaunch(true, false)
 		}

--- a/disc/discUtils.go
+++ b/disc/discUtils.go
@@ -323,7 +323,7 @@ func InteractionEphemeralResponse(i *discordgo.InteractionCreate, title, message
 
 // InteractionEphemeralResponseColor sends an ephemeral response with a specific embed color.
 func InteractionEphemeralResponseColor(i *discordgo.InteractionCreate, title, message string, color int) *discordgo.Message {
-	glob.BootMessage = nil
+	glob.SetBootMessage(nil)
 	glob.ResetUpdateMessage()
 
 	if DS == nil || i == nil {
@@ -357,7 +357,7 @@ func InteractionEphemeralResponseColor(i *discordgo.InteractionCreate, title, me
 
 // InteractionEphemeralFileResponse sends an ephemeral embed with an attached file.
 func InteractionEphemeralFileResponse(i *discordgo.InteractionCreate, title, message, filename string, data []byte) *discordgo.Message {
-	glob.BootMessage = nil
+	glob.SetBootMessage(nil)
 	glob.ResetUpdateMessage()
 
 	if DS == nil || i == nil {

--- a/discordMsg.go
+++ b/discordMsg.go
@@ -92,7 +92,7 @@ func handleDiscordMessages(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	//Kill continuity.
-	glob.BootMessage = nil
+	glob.SetBootMessage(nil)
 	glob.ResetUpdateMessage()
 
 	/* Factorio channel ONLY */

--- a/fact/util.go
+++ b/fact/util.go
@@ -172,14 +172,14 @@ func SetAutolaunch(autolaunch, report bool) {
 	if !autolaunch && FactAutoStart {
 		FactAutoStart = false
 		if report {
-			glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Notice", "Auto-reboot has been turned OFF.", glob.COLOR_GREEN)
+			glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Notice", "Auto-reboot has been turned OFF.", glob.COLOR_GREEN))
 		}
 		cwlog.DoLogCW("Autolaunch disabled.")
 	} else if autolaunch && !FactAutoStart {
 		FactAutoStart = true
 		cwlog.DoLogCW("Autolaunch enabled.")
 		if report {
-			glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Notice", "Auto-reboot has been ENABLED.", glob.COLOR_GREEN)
+			glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Notice", "Auto-reboot has been ENABLED.", glob.COLOR_GREEN))
 		}
 	}
 
@@ -206,10 +206,10 @@ func SetFactRunning(run, report bool) {
 		if report {
 			if run {
 				cwlog.DoLogGame("Factorio " + FactorioVersion + " is now online.")
-				glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Ready", "Factorio "+FactorioVersion+" is now online.", glob.COLOR_GREEN)
+				glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Ready", "Factorio "+FactorioVersion+" is now online.", glob.COLOR_GREEN))
 			} else {
 				cwlog.DoLogCW("Factorio has closed.")
-				glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Offline", "Factorio is now offline.", glob.COLOR_RED)
+				glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Offline", "Factorio is now offline.", glob.COLOR_RED))
 			}
 		}
 		UpdateChannelName()
@@ -362,7 +362,7 @@ func WriteWhitelist() int {
 /* Quit Factorio */
 func QuitFactorio(message string) {
 	if FactIsRunning {
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Notice", "Quitting Factorio: "+message, glob.COLOR_ORANGE)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Notice", "Quitting Factorio: "+message, glob.COLOR_ORANGE))
 	}
 
 	if message == "" {
@@ -1171,7 +1171,7 @@ func MakeSteamURL() (string, bool) {
 /* Program shutdown */
 func DoExit(delay bool) {
 
-	glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Status", constants.ProgName+" shutting down.", glob.COLOR_RED)
+	glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Status", constants.ProgName+" shutting down.", glob.COLOR_RED))
 
 	//Wait a few seconds for CMS to finish
 	for i := 0; i < 300; i++ {

--- a/glob/bootmsg.go
+++ b/glob/bootmsg.go
@@ -1,0 +1,18 @@
+package glob
+
+import "github.com/bwmarrin/discordgo"
+
+// SetBootMessage safely stores the boot message pointer.
+func SetBootMessage(m *discordgo.Message) {
+	BootMessageLock.Lock()
+	defer BootMessageLock.Unlock()
+	BootMessage = m
+}
+
+// GetBootMessage safely retrieves the boot message pointer.
+func GetBootMessage() *discordgo.Message {
+	BootMessageLock.Lock()
+	defer BootMessageLock.Unlock()
+	m := BootMessage
+	return m
+}

--- a/glob/var.go
+++ b/glob/var.go
@@ -16,6 +16,7 @@ var (
 	FactorioLock      sync.Mutex
 	UpdatersLock      sync.Mutex
 	BootMessage       *discordgo.Message
+	BootMessageLock   sync.Mutex
 	UpdateMessage     *discordgo.Message
 	UpdateMessageLock sync.Mutex
 

--- a/main.go
+++ b/main.go
@@ -223,9 +223,9 @@ func botReady(s *discordgo.Session, r *discordgo.Ready) {
 
 	//Only on first connect
 	if !support.BotIsReady {
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Status", constants.ProgName+" "+constants.Version+" is now online.", glob.COLOR_GREEN)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Status", constants.ProgName+" "+constants.Version+" is now online.", glob.COLOR_GREEN))
 		if fact.FactIsRunning || fact.FactorioBooted {
-			glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Ready", "Factorio "+fact.FactorioVersion+" is online.", glob.COLOR_GREEN)
+			glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Ready", "Factorio "+fact.FactorioVersion+" is online.", glob.COLOR_GREEN))
 		}
 	}
 

--- a/modupdate/newUpdate.go
+++ b/modupdate/newUpdate.go
@@ -280,11 +280,11 @@ func CheckModUpdates(dryRun bool) (bool, error) {
 		if fact.NumPlayers > 0 && shortBuf != "" {
 			fact.FactChat("Mod updates: " + shortBuf + " (Mods will update on reboot, when server is empty)")
 		}
-		glob.BootMessage = nil
+		glob.SetBootMessage(nil)
 		return true, nil
 	}
 
-	glob.BootMessage = nil
+	glob.SetBootMessage(nil)
 	return false, errors.New("No mod updates available.")
 }
 

--- a/support/launcher.go
+++ b/support/launcher.go
@@ -399,7 +399,7 @@ func launchFactorio() {
 	fact.SetLastBan("")
 
 	waitForDiscord()
-	glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Notice", "Launching Factorio...", glob.COLOR_GREEN)
+	glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Notice", "Launching Factorio...", glob.COLOR_GREEN))
 	fact.QueueFactReboot = false
 
 	/* Allow crash reports right away */
@@ -419,7 +419,7 @@ func launchFactorio() {
 		cfg.Global.Paths.Folders.FactorioDir
 
 	if _, err := os.Stat(checkFactPath); os.IsNotExist(err) {
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "ERROR", "Factorio is not installed. Use `/factorio install-factorio` to install it.", glob.COLOR_RED)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "ERROR", "Factorio is not installed. Use `/factorio install-factorio` to install it.", glob.COLOR_RED))
 
 		cwlog.DoLogCW("Factorio does not appear to be installed at the configured path: " + checkFactPath)
 		fact.SetAutolaunch(false, true)
@@ -429,7 +429,7 @@ func launchFactorio() {
 	/* Find, test and load newest save game available */
 	found, fileName, folderName := GetSaveGame(true)
 	if !found {
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "ERROR", "Unable to access save-games.", glob.COLOR_RED)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "ERROR", "Unable to access save-games.", glob.COLOR_RED))
 		fact.SetAutolaunch(false, true)
 		return
 	}
@@ -442,7 +442,7 @@ func launchFactorio() {
 
 		if delay > 0 {
 			buf := fmt.Sprintf("Rate limiting: Waiting for %v seconds before launching Factorio.", delay)
-			glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Warning", buf, glob.COLOR_ORANGE)
+			glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Warning", buf, glob.COLOR_ORANGE))
 
 			for i := 0; i < delay*11 && throt > 0 && glob.ServerRunning && glob.RelaunchThrottle > 0; i++ {
 				time.Sleep(100 * time.Millisecond)
@@ -505,7 +505,7 @@ func launchFactorio() {
 
 	modFiles := GetModFiles()
 	if len(modFiles) > 0 {
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "Status", "Loading mods...", glob.COLOR_GREEN)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "Status", "Loading mods...", glob.COLOR_GREEN))
 	}
 
 	if glob.FactorioCancel != nil {
@@ -535,7 +535,7 @@ func launchFactorio() {
 	if !fact.GenerateFactorioConfig() {
 		fact.SetAutolaunch(false, true)
 
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "ERROR", "Unable to write a config file for Fatorio.", glob.COLOR_RED)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "ERROR", "Unable to write a config file for Fatorio.", glob.COLOR_RED))
 
 		return
 	}
@@ -589,7 +589,7 @@ func launchFactorio() {
 	/* Factorio is not happy. */
 	if errp != nil {
 		fact.LogCMS(cfg.Local.Channel.ChatChannel, fmt.Sprintf("An error occurred when attempting to execute cmd.StdinPipe() Details: %s", errp))
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "ERROR", "Launching Factorio failed!", glob.COLOR_RED)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "ERROR", "Launching Factorio failed!", glob.COLOR_RED))
 
 		/* close lock  */
 		fact.DoExit(true)
@@ -607,7 +607,7 @@ func launchFactorio() {
 	err = glob.FactorioCmd.Start()
 	if err != nil {
 		fact.LogCMS(cfg.Local.Channel.ChatChannel, fmt.Sprintf("An error occurred when attempting to start the game. Details: %s", err))
-		glob.BootMessage = disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.BootMessage, "ERROR", "Launching Factorio failed!", glob.COLOR_RED)
+		glob.SetBootMessage(disc.SmartEditDiscordEmbed(cfg.Local.Channel.ChatChannel, glob.GetBootMessage(), "ERROR", "Launching Factorio failed!", glob.COLOR_RED))
 		fact.DoExit(true)
 		return
 	}

--- a/support/mainLoops.go
+++ b/support/mainLoops.go
@@ -165,7 +165,7 @@ func MainLoops() {
 							addlen := len(line)
 							if oldlen+addlen >= constants.MaxDiscordMsgLen {
 								disc.SmartWriteDiscord(cfg.Local.Channel.ChatChannel, buf)
-								glob.BootMessage = nil
+								glob.SetBootMessage(nil)
 								glob.ResetUpdateMessage()
 								buf = line
 							} else {
@@ -174,7 +174,7 @@ func MainLoops() {
 						}
 						if buf != "" {
 							disc.SmartWriteDiscord(cfg.Local.Channel.ChatChannel, buf)
-							glob.BootMessage = nil
+							glob.SetBootMessage(nil)
 							glob.ResetUpdateMessage()
 						}
 


### PR DESCRIPTION
## Summary
- add BootMessageLock and helper methods to manipulate BootMessage safely
- replace direct BootMessage usage across code with the new helpers

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68558ba87884832ab44076ab64c94288