### PR TITLE
Add watch tests

### DIFF
--- a/watcher/watch.go
+++ b/watcher/watch.go
@@ -7,6 +7,11 @@ import (
 	"ChatWire/cwlog"
 )
 
+// ErrSleepDuration controls how long Watch waits after encountering an
+// error while stat'ing the file. It is exported so tests can shorten the
+// delay from the default minute.
+var ErrSleepDuration = time.Minute
+
 // Watch monitors a file and invokes cb whenever the file is modified.
 // The loop stops when running is nil or *running becomes false.
 func Watch(path string, interval time.Duration, running *bool, cb func()) {
@@ -14,7 +19,7 @@ func Watch(path string, interval time.Duration, running *bool, cb func()) {
 		initial, err := os.Stat(path)
 		if err != nil {
 			cwlog.DoLogCW("watcher: initial stat error on %s: %v", path, err)
-			time.Sleep(time.Minute)
+			time.Sleep(ErrSleepDuration)
 			continue
 		}
 
@@ -25,7 +30,7 @@ func Watch(path string, interval time.Duration, running *bool, cb func()) {
 			stat, err := os.Stat(path)
 			if err != nil {
 				cwlog.DoLogCW("watcher: stat error on %s: %v", path, err)
-				time.Sleep(time.Minute)
+				time.Sleep(ErrSleepDuration)
 				break
 			}
 			if stat.Size() != initial.Size() || stat.ModTime() != initial.ModTime() {

--- a/watcher/watch_test.go
+++ b/watcher/watch_test.go
@@ -1,0 +1,73 @@
+package watcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Test callback triggers when a watched file is created and then modified.
+func TestWatchCreationEvent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	// Speed up retry loop on stat failures.
+	ErrSleepDuration = 10 * time.Millisecond
+
+	running := true
+	done := make(chan struct{})
+	go Watch(path, 5*time.Millisecond, &running, func() { close(done) })
+
+	// Give watcher time to start and attempt the first stat.
+	time.Sleep(20 * time.Millisecond)
+
+	// Create the file.
+	if err := os.WriteFile(path, []byte("first"), 0o644); err != nil {
+		t.Fatalf("creating file: %v", err)
+	}
+
+	// Modify it to trigger the watcher.
+	time.Sleep(20 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("second"), 0o644); err != nil {
+		t.Fatalf("modifying file: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("callback not triggered on creation")
+	}
+	running = false
+}
+
+// Test callback triggers when a watched file is modified.
+func TestWatchModificationEvent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+
+	if err := os.WriteFile(path, []byte("initial"), 0o644); err != nil {
+		t.Fatalf("creating file: %v", err)
+	}
+
+	ErrSleepDuration = 10 * time.Millisecond
+
+	running := true
+	done := make(chan struct{})
+	go Watch(path, 5*time.Millisecond, &running, func() { close(done) })
+
+	// Allow watcher to record initial state.
+	time.Sleep(20 * time.Millisecond)
+
+	// Modify the file.
+	if err := os.WriteFile(path, []byte("changed"), 0o644); err != nil {
+		t.Fatalf("writing file: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("callback not triggered on modification")
+	}
+	running = false
+}


### PR DESCRIPTION
## Summary
- add configurable error sleep duration to watcher
- test watch creation and modification events

## Testing
- `go test ./watcher`


------
https://chatgpt.com/codex/tasks/task_e_68558ba4b6d8832ab9f5fa9bb55868e3