### PR TITLE
Fix banlist logging

### DIFF
--- a/banlist/banList.go
+++ b/banlist/banList.go
@@ -117,7 +117,7 @@ func ReadBanFile(firstboot bool) {
 	err = json.Unmarshal(data, &names)
 
 	if err != nil {
-		fmt.Print("")
+		cwlog.DoLogCW("ReadBanFile: legacy format parse error: %v", err)
 		//Ignore error
 	}
 


### PR DESCRIPTION
## Summary
- remove empty `fmt.Print` from `banlist/banList.go`
- log legacy ban list parse errors via `cwlog.DoLogCW`

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6855973fae38832aa6708871c9146698