### PR TITLE
Fix cleanup on rename failure

### DIFF
--- a/util/fileutil.go
+++ b/util/fileutil.go
@@ -30,5 +30,9 @@ func WriteJSONAtomic(path string, data interface{}, perm os.FileMode) error {
 	if err := os.WriteFile(tempPath, outbuf.Bytes(), perm); err != nil {
 		return err
 	}
-	return os.Rename(tempPath, path)
+	if err := os.Rename(tempPath, path); err != nil {
+		_ = os.Remove(tempPath)
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- ensure temp file cleanup when `WriteJSONAtomic` fails on rename

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685597494458832a97cff0163290cb0d