### PR TITLE
Improve RandomBase64String fallback

### DIFF
--- a/cwlog/link.go
+++ b/cwlog/link.go
@@ -1,0 +1,7 @@
+package cwlog
+
+import "ChatWire/glob"
+
+func init() {
+	glob.CWLogger = DoLogCW
+}

--- a/glob/util.go
+++ b/glob/util.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"math"
+	mathrand "math/rand"
 )
 
 // Ptr returns a pointer to the provided value.
@@ -15,9 +16,19 @@ func Ptr[T any](v T) *T {
 // This is primarily used when generating map names.
 func RandomBase64String(l int) string {
 	buff := make([]byte, int(math.Ceil(float64(l)/float64(1.33333333333))))
-	_, _ = rand.Read(buff)
+	if _, err := rand.Read(buff); err != nil {
+		if CWLogger != nil {
+			CWLogger("RandomBase64String: rand.Read failure: %v", err)
+		}
+		for i := range buff {
+			buff[i] = byte(mathrand.Intn(256))
+		}
+	}
 
 	str := base64.RawURLEncoding.EncodeToString(buff)
 	/* strip 1 extra character we get from odd length results */
+	if len(str) < l {
+		return ""
+	}
 	return str[:l]
 }

--- a/glob/var.go
+++ b/glob/var.go
@@ -54,6 +54,9 @@ var (
 	CWLogDesc    *os.File
 	AuditLogDesc *os.File
 
+	// CWLogger is set by the cwlog package and should point to cwlog.DoLogCW.
+	CWLogger func(format string, args ...interface{})
+
 	/* CW reboot */
 	DoRebootCW = false
 


### PR DESCRIPTION
## Summary
- add logging hook in `glob` and connect it through `cwlog`
- handle `rand.Read` failure in `glob.RandomBase64String` with fallback bytes

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_685597747940832ab0f6056b5762a5cc